### PR TITLE
Ensure Supabase writes persist locally

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
             const { error } = await window.supabase
               .from(window.SUPABASE_TABLE)
               .upsert({ key, value }, { onConflict: 'key' });
+            try { localStorage.setItem(key, JSON.stringify(value)); } catch {}
             if (error) console.warn('writeKV error', error);
           } else {
             try { localStorage.setItem(key, JSON.stringify(value)); } catch {}


### PR DESCRIPTION
## Summary
- Mirror `writeKV` Supabase upserts to `localStorage` for immediate state persistence

## Testing
- `node - <<'NODE' ... NODE`


------
https://chatgpt.com/codex/tasks/task_e_68bfd06a078c8328819f9410e6d1411d