### PR TITLE
Align Supabase config with browser project

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,2 +1,6 @@
-window.SUPABASE_URL = "https://nhbtlcxswtdgxrdteish.supabase.co";
-window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5oYnRsY3hzd3RkZ3hyZHRlaXNoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTU0MzE4MjYsImV4cCI6MjA3MTAwNzgyNn0.XPM8cDSylM1_675zMh9aXtwZPqA7ZTAQG88WMuxW1FA";
+// Configuration values shared with the browser environment
+// Ensure these match the Supabase project the application is using
+window.SUPABASE_URL = "https://qzkzugzfpegozpiqutdv.supabase.co";
+window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InF6a3p1Z3pmcGVnb3pwaXF1dGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTU4MTc5MDMsImV4cCI6MjA3MTM5MzkwM30.mdFYuFjbRfsILWPkQQmVUCDR7dGqEo-mdPZ6iwolvGk";
+// Provide SUPABASE_KEY for scripts expecting this name
+window.SUPABASE_KEY = window.SUPABASE_ANON_KEY;


### PR DESCRIPTION
## Summary
- align Supabase URL and anon key with the browser's configuration
- expose SUPABASE_KEY alias for scripts expecting this variable

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c015e769d883289774acb2a44c58d1