### PR TITLE
Fix settings tabs visibility and set default active tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -672,7 +672,7 @@ window.addEventListener('load', dashReports);
 
  <style id="settingsScopedStyles">
   #panelSettings { --border:#e2e8f0; --accent:#FFD700; }
-  #panelSettings .tabs { display:flex;gap:6px;flex-wrap:wrap }
+  #panelSettings .tabs { display:flex !important;gap:6px;flex-wrap:wrap }
   #panelSettings .tab-btn { padding:8px 12px;border:1px solid var(--border);background:white;border-radius:8px;cursor:pointer }
   #panelSettings .tab-btn.active { background:var(--accent);color:white;border-color:var(--accent) }
   #panelSettings .tab { display:none }
@@ -1553,7 +1553,7 @@ window.addEventListener('load', dashReports);
    <header>
     <h2>Settings</h2>
     <div class="tabs">
-     <button class="tab-btn" data-tab="employees">Employees</button>
+     <button class="tab-btn active" data-tab="employees">Employees</button>
      <button class="tab-btn" data-tab="schedule">Schedule</button>
      <button class="tab-btn" data-tab="projects">Projects</button>
     </div>


### PR DESCRIPTION
## Summary
- Ensure settings tabs are visible by forcing flex layout
- Default the Employees tab to active in settings header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c03fc96d1c8328b3f608748787c526