### PR TITLE
Avoid mixing nullish coalescing and OR for project IDs

### DIFF
--- a/index.html
+++ b/index.html
@@ -4651,7 +4651,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const tr = document.createElement('tr');
         function cell(el){ const td=document.createElement('td'); td.appendChild(el); tr.appendChild(td); }
         const idInput = document.createElement('input');
-        idInput.value = p.id ?? p.projectId ?? rec.key || '';
+        idInput.value = p.id ?? p.projectId ?? rec.key ?? '';
         idInput.style.width = '100%';
         idInput.addEventListener('change', () => updateProjectField(rec, 'id', idInput.value));
         cell(idInput);


### PR DESCRIPTION
## Summary
- Use consistent nullish coalescing for project ID inputs to avoid mixing `??` and `||` operators.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0533a500c83288d8d4a27a4275eec