### PR TITLE
Restrict unsplitting to segments with matching project

### DIFF
--- a/index.html
+++ b/index.html
@@ -5250,6 +5250,34 @@ function splitRecord(key) {
   renderResults();
 }
 function unsplitRecord(key) {
+  const [empId, date] = key.split('___');
+  const halves = ['AM', 'PM', 'OT'];
+  const dayKey = empId + '___' + date;
+  const emp = (typeof storedEmployees !== 'undefined' && storedEmployees[empId]) ? storedEmployees[empId] : {};
+  const baseProj = (overridesProjects && Object.prototype.hasOwnProperty.call(overridesProjects, dayKey))
+    ? overridesProjects[dayKey]
+    : (emp.projectId || '');
+  const projIds = halves.map(h => {
+    const hk = empId + '___' + date + '___' + h;
+    if (overridesProjects && Object.prototype.hasOwnProperty.call(overridesProjects, hk)) {
+      return overridesProjects[hk];
+    }
+    return baseProj;
+  });
+  const firstProj = projIds[0];
+  const allSame = projIds.every(pid => pid === firstProj);
+  if (!allSame) {
+    alert('Cannot unsplit: segments must have the same project before they can be merged.');
+    return;
+  }
+  halves.forEach(h => {
+    const hk = empId + '___' + date + '___' + h;
+    if (overridesProjects && Object.prototype.hasOwnProperty.call(overridesProjects, hk)) {
+      delete overridesProjects[hk];
+    }
+  });
+  overridesProjects[dayKey] = firstProj;
+  saveOverrides();
   splits[key] = false;
   saveSplits();
   renderResults();


### PR DESCRIPTION
## Summary
- Prevent unsplitting a record if AM/PM/OT segments have different project overrides
- Consolidate half-day project overrides into a single day override when segments match

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f4980cc083288e2848d87bc55a8f