### PR TITLE
Clean up project overrides on unsplit

### DIFF
--- a/index.html
+++ b/index.html
@@ -5252,6 +5252,24 @@ function splitRecord(key) {
 function unsplitRecord(key) {
   splits[key] = false;
   saveSplits();
+
+  // Consolidate project overrides when unsplitting a record.  If AM/PM/OT
+  // segments all share the same project, migrate that assignment to the
+  // day-level key and drop any half-specific entries so future lookups use a
+  // single consolidated override.
+  const [empId, date] = key.split('___');
+  const dayKey = empId + '___' + date;
+  const halfPrefix = dayKey + '___';
+  const halfKeys = Object.keys(overridesProjects || {}).filter(k => k.startsWith(halfPrefix));
+  if (halfKeys.length > 0) {
+    const firstProj = overridesProjects[halfKeys[0]];
+    const allSame = halfKeys.every(k => overridesProjects[k] === firstProj);
+    if (allSame) {
+      overridesProjects[dayKey] = firstProj;
+      halfKeys.forEach(k => delete overridesProjects[k]);
+    }
+  }
+  saveOverrides();
   renderResults();
 }
 function saveOverrides(){


### PR DESCRIPTION
## Summary
- Consolidate half-specific project overrides when unsplitting a record
- Persist updated overrides and refresh results

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f6465cb48328abf6dbfd397e5cbb