### PR TITLE
Clean up project overrides after unsplitting

### DIFF
--- a/index.html
+++ b/index.html
@@ -5296,6 +5296,12 @@ function unsplitRecord(key) {
       }
     });
   }
+  halves.forEach(h => {
+    const hk = dayKey + '___' + h;
+    if (!splitState[h] && overridesProjects && Object.prototype.hasOwnProperty.call(overridesProjects, hk)) {
+      delete overridesProjects[hk];
+    }
+  });
   if (splitState && Object.keys(splitState).length > 0) {
     splits[dayKey] = splitState;
   } else {


### PR DESCRIPTION
## Summary
- remove half-level project overrides once segments are merged
- keep overrides only for remaining split segments or the merged day project
- persist project overrides after cleanup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c10b23f90c83289ee0691ae996a4e9