### PR TITLE
Add DTR delete buttons during render

### DIFF
--- a/index.html
+++ b/index.html
@@ -7407,11 +7407,21 @@ tabs.tabPayroll.addEventListener('click', () => {
   }
   function init(){
     wireManualDTR();
+    const callRender = () => {
+      try {
+        if (typeof renderResults === 'function') renderResults();
+      } catch(e){}
+    };
     if(!patchRenderResults()){
       const iv = setInterval(() => {
-        if(patchRenderResults()) clearInterval(iv);
+        if(patchRenderResults()){
+          clearInterval(iv);
+          callRender();
+        }
       }, 200);
       setTimeout(() => clearInterval(iv), 6000);
+    } else {
+      callRender();
     }
   }
   if(document.readyState === 'loading'){
@@ -10037,6 +10047,7 @@ document.addEventListener('DOMContentLoaded', async function () {
   function afterRender(){
     applyOverridesToTable();
     addDtrEditorButtons();
+    addDtrDeleteButtons();
     recomputeDtrSummaryFromTable();
   }
 


### PR DESCRIPTION
## Summary
- Include `addDtrDeleteButtons()` in `afterRender` so delete controls appear with editor buttons
- Keep `patchOnce` wrapper around `renderResults` and re-render once after patching

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c110109ee08328a10bfb4e8181ea83