### PR TITLE
Fix undefined dayKey in combined row rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -6518,7 +6518,7 @@ let otMins = 0;
           htmlComb += '<td>' + formatHours(__totComb) + '</td>';
           htmlComb += '<td><button type="button" class="btn-split" data-key="' + splitKey + '" onclick="splitRecord(this.dataset.key)">Split</button></td>';
           trComb.innerHTML = htmlComb;
-          if (overridesSchedules[dayKey] || overridesProjects[dayKey] !== undefined) {
+          if (overridesSchedules[splitKey] || overridesProjects[splitKey] !== undefined) {
             trComb.style.backgroundColor = '#fff3cd';
           }
           try {


### PR DESCRIPTION
## Summary
- Use splitKey for override lookup in combined row rendering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ea11893c8328a2343503be9f643e