### PR TITLE
Expose addDtrDeleteButtons globally

### DIFF
--- a/index.html
+++ b/index.html
@@ -7386,6 +7386,8 @@ tabs.tabPayroll.addEventListener('click', () => {
       tr.appendChild(td);
     });
   }
+  // Expose deletion utility globally so other scripts can invoke it
+  window.addDtrDeleteButtons = addDtrDeleteButtons;
   function patchRenderResults(){
     if(typeof renderResults !== 'function') return false;
     const original = renderResults;


### PR DESCRIPTION
## Summary
- Fix ReferenceError by exposing `addDtrDeleteButtons` on the global `window` so later scripts can use it

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c112f3f01c832888df42a583b216bd