### PR TITLE
Guard DTR delete button usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -10049,7 +10049,7 @@ document.addEventListener('DOMContentLoaded', async function () {
   function afterRender(){
     applyOverridesToTable();
     addDtrEditorButtons();
-    addDtrDeleteButtons();
+    if (typeof addDtrDeleteButtons === 'function') addDtrDeleteButtons();
     recomputeDtrSummaryFromTable();
   }
 


### PR DESCRIPTION
## Summary
- Avoid ReferenceError when optional DTR deletion helper isn't loaded by checking for its presence before calling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c113e2f3288328b0cccde278a3ed00