### PR TITLE
Move Bantay column before gross pay

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@ function safeStringify(v){
   }
 
 /* === PATCH: Bantay column width === */
-#payrollTable th:nth-child(20), #payrollTable td:nth-child(20) { width: 100px; min-width: 100px; }
+#payrollTable th:nth-child(10), #payrollTable td:nth-child(10) { width: 100px; min-width: 100px; }
 /* === END PATCH === */
 
 /* === PERF: faster layout for payroll table === */
@@ -544,9 +544,7 @@ window.addEventListener('load', dashReports);
 
   /* Hide individual deduction columns in Payroll table (show only Total Deductions).
      After adding the Adjustment Hrs column, the indices shift by one.
-     Hide Pagâ€‘IBIG to Wed Vale columns (cols 10â€“16). */
-  #payrollTab #payrollTable th:nth-child(11),
-  #payrollTab #payrollTable td:nth-child(11),
+     Hide Pagâ€‘IBIG to Wed Vale columns (cols 12â€“18). */
   #payrollTab #payrollTable th:nth-child(12),
   #payrollTab #payrollTable td:nth-child(12),
   #payrollTab #payrollTable th:nth-child(13),
@@ -558,7 +556,9 @@ window.addEventListener('load', dashReports);
   #payrollTab #payrollTable th:nth-child(16),
   #payrollTab #payrollTable td:nth-child(16),
   #payrollTab #payrollTable th:nth-child(17),
-  #payrollTab #payrollTable td:nth-child(17) { display: none; }
+  #payrollTab #payrollTable td:nth-child(17),
+  #payrollTab #payrollTable th:nth-child(18),
+  #payrollTab #payrollTable td:nth-child(18) { display: none; }
 /* === PATCH: column widths for Hourly Rate, Regular Hours, OT Hours === */
 #payrollTable th, #payrollTable td { white-space: nowrap; }
 #payrollTable th:nth-child(3), #payrollTable td:nth-child(3) { width: 110px; min-width: 110px; } /* Hourly Rate */
@@ -1791,6 +1791,9 @@ window.addEventListener('load', dashReports);
          OT Pay
         </th>
         <th>
+         Bantay
+        </th>
+        <th>
          Gross Pay
         </th>
         <th>
@@ -1821,9 +1824,6 @@ window.addEventListener('load', dashReports);
          Adjustments
         </th>
         <th>
-         Bantay
-        </th>
-        <th>
          Net Pay
         </th>
         <th>
@@ -1843,6 +1843,7 @@ window.addEventListener('load', dashReports);
     <td class="num" data-col="totalHrs">0.00</td>
     <td class="num" data-col="regPay">0.00</td>
     <td class="num" data-col="otPay">0.00</td>
+    <td class="num" data-col="bantay">0.00</td>
     <td class="num" data-col="grossPay">0.00</td>
     <td class="num" data-col="pagibig">0.00</td>
     <td class="num" data-col="philhealth">0.00</td>
@@ -1853,7 +1854,6 @@ window.addEventListener('load', dashReports);
     <td class="num" data-col="valeWed">0.00</td>
     <td class="num" data-col="totalDed">0.00</td>
     <td class="num" data-col="adjAmt">0.00</td>
-    <td class="num" data-col="bantay">0.00</td>
     <td class="num" data-col="netPay">0.00</td>
     <td></td>
   </tr>
@@ -2625,6 +2625,7 @@ function renderTable(){
         <td><input class="cell otHrs" title="Non-editable in Payroll" type="number" step="0.01" value="${oH}" disabled></td>
         <td class="adjHrs num">${aH ? aH.toFixed(2) : '0.00'}</td><td class="totalHrs num">0.00</td><td class="regPay num">0.00</td>
         <td class="otPay num">0.00</td>
+        <td><input class="cell bantay" type="number" step="0.01" value="${bVal}"></td>
         <td class="grossPay num">0.00</td>
         <td class="pagibig num">0.00</td>
         <td class="philhealth num">0.00</td>
@@ -2635,7 +2636,6 @@ function renderTable(){
         <td class="valeWed num">${vW}</td>
         <td class="totalDed num">0.00</td>
         <td class="adjAmt num">0.00</td>
-        <td><input class="cell bantay" type="number" step="0.01" value="${bVal}"></td>
         <td class="netPay num">0.00</td>
         <td><button type="button" class="payslipBtn">Payslip</button></td>`;
       frag.appendChild(tr);
@@ -3641,8 +3641,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
       // Column index fallbacks aligned with current payrollTable structure
       // 0:ID, 1:Name, 2:Rate, 3:RegHrs, 4:OTHrs, 5:AdjHrs, 6:TotalHrs, 7:RegPay, 8:OTPay,
-      // 9:Gross, 10:Pag-IBIG, 11:PhilHealth, 12:SSS, 13:SSS Loan, 14:Pag-IBIG Loan,
-      // 15:Vale, 16:Wed Vale, 17:Total Ded, 18:Adjustments, 19:Bantay, 20:Net Pay, 21:Payslip
+      // 9:Bantay, 10:Gross, 11:Pag-IBIG, 12:PhilHealth, 13:SSS, 14:SSS Loan, 15:Pag-IBIG Loan,
+      // 16:Vale, 17:Wed Vale, 18:Total Ded, 19:Adjustments, 20:Net Pay, 21:Payslip
       data.rate = readNum('.rate', 2);
       data.regHrs = readNum('.regHrs', 3);
       data.otHrs = readNum('.otHrs', 4);
@@ -3650,17 +3650,17 @@ document.addEventListener('DOMContentLoaded', () => {
       data.totalHrs = readNum('.totalHrs', 6);
       data.regPay = readNum('.regPay', 7);
       data.otPay = readNum('.otPay', 8);
-      data.grossPay = readNum('.grossPay', 9);
-      data.pagibig = readNum('.pagibig', 10);
-      data.philhealth = readNum('.philhealth', 11);
-      data.sss = readNum('.sss', 12);
-      data.loanSSS = readNum('.loanSSS', 13);
-      data.loanPI = readNum('.loanPI', 14);
-      data.vale = readNum('.vale', 15);
-      data.valeWed = readNum('.valeWed', 16);
-      data.totalDed = readNum('.totalDed', 17);
-      data.adjAmt = readNum('.adjAmt', 18);
-      data.bantay = readNum('.bantay', 19);
+      data.bantay = readNum('.bantay', 9);
+      data.grossPay = readNum('.grossPay', 10);
+      data.pagibig = readNum('.pagibig', 11);
+      data.philhealth = readNum('.philhealth', 12);
+      data.sss = readNum('.sss', 13);
+      data.loanSSS = readNum('.loanSSS', 14);
+      data.loanPI = readNum('.loanPI', 15);
+      data.vale = readNum('.vale', 16);
+      data.valeWed = readNum('.valeWed', 17);
+      data.totalDed = readNum('.totalDed', 18);
+      data.adjAmt = readNum('.adjAmt', 19);
       data.netPay = readNum('.netPay', 20);
       // Capture DTR records for this employee within the selected date range. Stores an array of {date, times}
       try {
@@ -3917,19 +3917,19 @@ document.addEventListener('DOMContentLoaded', () => {
     // Mirror the payroll grid ordering, including adjustment/total hours and Bantay
     const header = [
       'ID','Name','Hourly Rate','Regular Hours','OT Hours','Adjustment Hours','Total Hours',
-      'Regular Pay','OT Pay','Gross Pay',
+      'Regular Pay','OT Pay','Bantay','Gross Pay',
       'Pag-IBIG','PhilHealth','SSS','SSS Loan','Pag-IBIG Loan','Vale','Wed Vale',
-      'Total Deductions','Adjustments','Bantay','Net Pay'
+      'Total Deductions','Adjustments','Net Pay'
     ];
     const lines = [header.join(',')];
     snap.rows.forEach(row => {
       const values = [
         row.id, row.name,
         row.rate, row.regHrs, row.otHrs, row.adjHrs, row.totalHrs,
-        row.regPay, row.otPay, row.grossPay,
+        row.regPay, row.otPay, row.bantay, row.grossPay,
         row.pagibig, row.philhealth, row.sss,
         row.loanSSS, row.loanPI, row.vale, row.valeWed,
-        row.totalDed, row.adjAmt, row.bantay, row.netPay
+        row.totalDed, row.adjAmt, row.netPay
       ];
       lines.push(values.map(v => {
         const s = String(v ?? '');
@@ -4232,9 +4232,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // Display columns similar to the live payroll grid (omit Total Deductions per request)
     const headers = [
       'ID','Name','Hourly Rate','Regular Hrs','OT Hrs','Adjustment Hrs','Total Hours',
-      'Reg Pay','OT Pay','Gross',
+      'Reg Pay','OT Pay','Bantay','Gross',
       'Pag-IBIG','PhilHealth','SSS','SSS Loan','Pag-IBIG Loan','Vale','Wed Vale',
-      'Adjustments','Bantay','Net Pay'
+      'Adjustments','Net Pay'
     ];
     headers.forEach(h => {
       const th = document.createElement('th');
@@ -4312,10 +4312,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const vals = [
         id, r.name, rate, regHrs, otHrs, adjHrs, totalHrs,
-        regPay, otPay, gross,
+        regPay, otPay, bantay, gross,
         pagibig, philhealth, sss,
         loanSSSPer, loanPIPer, vale, wedVale,
-        adjAmt, bantay, netPay
+        adjAmt, netPay
       ];
       // Accumulate grand totals
       GT.regHrs     += regHrs;
@@ -4367,13 +4367,13 @@ document.addEventListener('DOMContentLoaded', () => {
     label.style.border = '1px solid #e2e8f0';
     label.style.padding = '4px';
     ft.appendChild(label);
-    const cells = [
-      GT.regHrs, GT.otHrs, GT.adjHrs, GT.totalHrs,
-      GT.regPay, GT.otPay, GT.gross,
-      GT.pagibig, GT.philhealth, GT.sss,
-      GT.loanSSS, GT.loanPI, GT.vale, GT.wedVale,
-      GT.adjAmt, GT.bantay, GT.netPay
-    ];
+      const cells = [
+        GT.regHrs, GT.otHrs, GT.adjHrs, GT.totalHrs,
+        GT.regPay, GT.otPay, GT.bantay, GT.gross,
+        GT.pagibig, GT.philhealth, GT.sss,
+        GT.loanSSS, GT.loanPI, GT.vale, GT.wedVale,
+        GT.adjAmt, GT.netPay
+      ];
     cells.forEach(n => {
       const td = document.createElement('td');
       const val = Number(n) || 0;


### PR DESCRIPTION
## Summary
- Reorder Bantay column before Gross Pay across payroll table, totals footer, and row templates
- Update styles for new Bantay index and adjusted deduction column visibility
- Revise snapshot/CSV structures to align with new column ordering

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1369c59b48328aab00ccfcc103dee