### PR TITLE
Reset Bantay maps on new period

### DIFF
--- a/index.html
+++ b/index.html
@@ -1050,6 +1050,9 @@ window.addEventListener('load', dashReports);
       }catch(_){ }
       await window.writeKVScoped(base, val, pid);
     }
+    // Force-reset Bantay maps each new period
+    await window.writeKVScoped('payroll_bantay', {}, pid);
+    await window.writeKVScoped('payroll_bantay_proj', {}, pid);
   }
   async function hydratePeriodKV(pid){
     if (!supa()) return; // local snapshots already in LS


### PR DESCRIPTION
## Summary
- Force-reset `payroll_bantay` and `payroll_bantay_proj` maps when cloning globals to a new payroll period

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1af57b5448328a5d0055a2653c220