### PR TITLE
Add DTR per-period Supabase persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -1306,6 +1306,47 @@ window.addEventListener('load', dashReports);
 </script>
 <!-- === / PERIOD HYDRATE ON SWITCH v1 === -->
 
+<!-- === DTR PER-PERIOD v1 === -->
+<script>
+(function(){
+  const supa = () => (window.supabase || null);
+  if (!supa()) return;
+
+  const DTR_TABLE = 'dtr_records';
+  function pid(){ return (typeof window.getActivePeriodId==='function') ? window.getActivePeriodId() : 'UNSCOPED'; }
+
+  window.saveDTRForCurrentPeriod = async function(rows){
+    try{
+      await supa().from(DTR_TABLE).upsert({ id: pid(), data: Array.isArray(rows)?rows:[] }, { onConflict:'id' });
+      window.storedRecords = Array.isArray(rows)?rows:[];
+      try{ localStorage.setItem('att_records_v2', JSON.stringify(window.storedRecords)); }catch(_){ }
+      return true;
+    }catch(e){ console.warn('Per-period DTR save failed', e); return false; }
+  };
+  window.loadDTRForCurrentPeriod = async function(){
+    try{
+      const { data, error } = await supa().from(DTR_TABLE).select('*').eq('id', pid()).single();
+      if (!error && data && Array.isArray(data.data)) return data.data;
+    }catch(_){ }
+    return [];
+  };
+
+  // Hook if legacy functions exist
+  if (typeof window.fetchDTR === 'function'){
+    const orig = window.fetchDTR;
+    window.fetchDTR = async function(){
+      const rows = await window.loadDTRForCurrentPeriod();
+      return { rows, error: null };
+    };
+  }
+  if (typeof window.applyDTR === 'function'){
+    const orig2 = window.applyDTR;
+    window.applyDTR = async function(rows){ await window.saveDTRForCurrentPeriod(rows); return true; };
+  }
+})();
+</script>
+<!-- === / DTR PER-PERIOD v1 === -->
+
 </head>
 
 <!-- UI fixes: restore emojis and icons if text got corrupted by encoding -->


### PR DESCRIPTION
## Summary
- Add per-period DTR save/load functions using Supabase
- Hook legacy fetch/apply DTR functions to use period-based storage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bee605308328a9a3fddbb3898417