### PR TITLE
Add inline favicon to prevent 404

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>PayrollPro</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI+CjxyZWN0IHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgcng9IjIiIHJ5PSIyIiBmaWxsPSIjNENBRjUwIi8+Cjx0ZXh0IHg9IjgiIHk9IjEyIiBmb250LXNpemU9IjEyIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSJ3aGl0ZSI+UDwvdGV4dD4KPC9zdmc+">
 
 <!-- === Supabase KV Sync Adapter (no-login, auto-sync) === -->
 <script>


### PR DESCRIPTION
## Summary
- Provide an inline SVG favicon to stop browsers from requesting a missing `favicon.ico`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c205c8eaf48328be2cab6d24d7fa48