### PR TITLE
Use payroll period dates for DAT/TXT upload filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -6122,10 +6122,10 @@ document.getElementById('fileInput').addEventListener('change', (ev)=>{
 // === MIN PATCH: Only keep records inside the current payroll period (From/To) ===
 let __from = '', __to = '';
 try {
-  const fEl = document.getElementById('dtrDateFrom');
-  const tEl = document.getElementById('dtrDateTo');
-  __from = (fEl && fEl.value) ? fEl.value : (localStorage.getItem('dtr_filter_from') || '');
-  __to   = (tEl && tEl.value) ? tEl.value : (localStorage.getItem('dtr_filter_to')   || '');
+  const fEl = document.getElementById('weekStart');
+  const tEl = document.getElementById('weekEnd');
+  __from = (fEl && fEl.value) ? fEl.value : (localStorage.getItem('payroll_week_start') || '');
+  __to   = (tEl && tEl.value) ? tEl.value : (localStorage.getItem('payroll_week_end')   || '');
 } catch(_) {}
 function __inRange(d){
   if (!d) return false;


### PR DESCRIPTION
## Summary
- Use payroll period inputs to determine the date range when filtering DAT/TXT uploads

## Testing
- `node test_upload.js` (sample DAT/TXT filtering)
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c23e4a3e608328b397c855d0891431