### PR TITLE
Fix OT calculation across midnight

### DIFF
--- a/index.html
+++ b/index.html
@@ -7218,7 +7218,10 @@ const otInActual = pickEarliest({start: schedule.rng_ot_in_start, end: schedule.
     } else {
       // Nonâ€‘Saturday: prefer explicit OT punches when they exist
       if (otInActual && otOutActual && toMins(otInActual) > pmOutRefMins) {
-        dayOTMins = Math.max(0, toMins(otOutActual) - toMins(otInActual));
+        let otInM = toMins(otInActual);
+        let otOutM = toMins(otOutActual);
+        if (otOutM < otInM) otOutM += 1440;
+        dayOTMins = Math.max(0, otOutM - otInM);
       } else {
         // Fallback: no explicit OT punches.  Check the last clockâ€‘out and
         // count any minutes worked after the scheduled end as OT.  Only
@@ -7231,8 +7234,12 @@ const otInActual = pickEarliest({start: schedule.rng_ot_in_start, end: schedule.
           const outM = toMins(outStr);
           if (lastOutM === null || outM > lastOutM) lastOutM = outM;
         }
-        if (lastOutM != null && lastOutM > pmOutRefMins) {
-          dayOTMins = lastOutM - pmOutRefMins;
+        if (lastOutM != null) {
+          let adjLastOut = lastOutM;
+          if (adjLastOut < pmOutRefMins) adjLastOut += 1440;
+          if (adjLastOut > pmOutRefMins) {
+            dayOTMins = adjLastOut - pmOutRefMins;
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- handle cross-midnight OT punches by adding a day when out < in
- apply the same cross-midnight handling when falling back to last clock-out

## Testing
- `node - <<'NODE'
const fs=require('fs');
const html=fs.readFileSync('index.html','utf8');
const funcMatch=html.match(/function computeHoursForDateRange[\s\S]*?return { totalsReg, totalsOT };\s*}\n/);
if(!funcMatch) throw new Error('function not found');
eval(funcMatch[0]);
const storedEmployees={'1':{scheduleId:'default'}};
const defaultScheduleId='default';
const overridesSchedules={};
const DEFAULT_SCHEDULE={
  sch_am_start:'08:00', sch_am_end:'12:00',
  sch_pm_start:'13:00', sch_pm_end:'17:00',
  sch_grace:0,
  rng_am_in_start:'05:00', rng_am_in_end:'09:00',
  rng_am_out_start:'11:30', rng_am_out_end:'12:30',
  rng_pm_in_start:'12:30', rng_pm_in_end:'14:30',
  rng_pm_out_start:'15:00', rng_pm_out_end:'17:30',
  rng_ot_in_start:'18:00', rng_ot_in_end:'23:00',
  rng_ot_out_start:'00:00', rng_ot_out_end:'06:00'
};
const storedSchedules={'default':DEFAULT_SCHEDULE};
let storedRecords=[
  {date:'2024-01-01', empId:'1', time:'08:00'},
  {date:'2024-01-01', empId:'1', time:'12:00'},
  {date:'2024-01-01', empId:'1', time:'13:00'},
  {date:'2024-01-01', empId:'1', time:'17:00'},
  {date:'2024-01-01', empId:'1', time:'18:00'},
  {date:'2024-01-01', empId:'1', time:'02:00'},
];
const res=computeHoursForDateRange('2024-01-01','2024-01-01');
console.log(res);
NODE`
- `node - <<'NODE'
let lastOutM=120, pmOutRefMins=1020, dayOTMins=0;
let adjLastOut=lastOutM;
if(adjLastOut<pmOutRefMins) adjLastOut+=1440;
if(adjLastOut>pmOutRefMins) dayOTMins=adjLastOut-pmOutRefMins;
console.log('fallback dayOTMins:', dayOTMins);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68c2634916708328a3c6f48829f740be