### PR TITLE
Fix Saturday overtime loop pairing

### DIFF
--- a/index.html
+++ b/index.html
@@ -7203,10 +7203,9 @@ const otInActual = pickEarliest({start: schedule.rng_ot_in_start, end: schedule.
       // minutes without regard to explicit OT punches.
       let extraOTMins = 0;
       const satEndM = toMins(__satEnd);
-      for (let i = 0; i < times.length; i += 2) {
+      for (let i = 0; i + 1 < times.length; i += 2) {
         const inStr  = times[i];
         const outStr = times[i+1];
-        if (!outStr) continue;
         const inM  = toMins(inStr);
         const outM = toMins(outStr);
         const startM = Math.max(inM, satEndM);


### PR DESCRIPTION
## Summary
- Ensure Saturday overtime logic iterates over complete in/out pairs only
- Remove redundant guard for missing out times

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d5a80da483289eca545efe039a6f