### PR TITLE
Simplify Saturday OT accumulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -7201,7 +7201,6 @@ const otInActual = pickEarliest({start: schedule.rng_ot_in_start, end: schedule.
       // Saturday override: sum minutes worked after the Saturday end for
       // every recorded segment.  Each segment contributes its own OT
       // minutes without regard to explicit OT punches.
-      let extraOTMins = 0;
       const satEndM = toMins(__satEnd);
       for (let i = 0; i + 1 < times.length; i += 2) {
         const inStr  = times[i];
@@ -7210,10 +7209,9 @@ const otInActual = pickEarliest({start: schedule.rng_ot_in_start, end: schedule.
         const outM = toMins(outStr);
         const startM = Math.max(inM, satEndM);
         if (outM > startM) {
-          extraOTMins += (outM - startM);
+          dayOTMins += (outM - startM);
         }
       }
-      dayOTMins = extraOTMins;
     } else {
       // Non-Saturday: prefer explicit OT punches when they exist
       if (otInActual && otOutActual && toMins(otInActual) > pmOutRefMins) {


### PR DESCRIPTION
## Summary
- accumulate Saturday overtime directly in `dayOTMins`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d62e19c483288704b963fa9f4ae6