### PR TITLE
Validate time format handling and add unit tests

### DIFF
--- a/src/calculate.js
+++ b/src/calculate.js
@@ -1,7 +1,11 @@
 // Utility helpers
 function toMins(str){
   if (typeof str !== 'string') return NaN;
-  const [h,m] = str.split(':').map(Number);
+  const match = /^([0-9]{1,2}):([0-9]{2})$/.exec(str);
+  if (!match) return NaN;
+  const h = Number(match[1]);
+  const m = Number(match[2]);
+  if (h < 0 || h > 23 || m < 0 || m > 59) return NaN;
   return h*60 + m;
 }
 function minsToStr(mins){
@@ -35,6 +39,9 @@ function isNextDay(inStr, outStr){
  */
 function adjustOvernight(inStr, outStr, empId, dateStr){
   if (!inStr || !outStr) return [inStr, outStr];
+  if (isNaN(toMins(inStr)) || isNaN(toMins(outStr))) {
+    throw new Error('Invalid time format');
+  }
   let [inM, outM] = bridgeMidnight(inStr, outStr);
   if (isNextDay(inStr, outStr)) {
     const cutoff = 6 * 60 + 30; // 06:30 in minutes
@@ -52,4 +59,4 @@ function adjustOvernight(inStr, outStr, empId, dateStr){
   return [minsToStr(inM), minsToStr(outM)];
 }
 
-module.exports = { adjustOvernight };
+module.exports = { adjustOvernight, toMins };

--- a/test/calculate.test.js
+++ b/test/calculate.test.js
@@ -1,0 +1,36 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { adjustOvernight, toMins } = require('../src/calculate');
+
+test('toMins parses valid times', () => {
+  assert.strictEqual(toMins('07:30'), 450);
+  assert.strictEqual(toMins('00:00'), 0);
+  assert.strictEqual(toMins('23:59'), 1439);
+});
+
+test('toMins rejects invalid times', () => {
+  assert.ok(Number.isNaN(toMins('24:00')));
+  assert.ok(Number.isNaN(toMins('12:60')));
+  assert.ok(Number.isNaN(toMins('7:5')));
+  assert.ok(Number.isNaN(toMins('ab:cd')));
+  assert.ok(Number.isNaN(toMins(123)));
+});
+
+test('adjustOvernight caps times past cutoff', () => {
+  assert.deepStrictEqual(
+    adjustOvernight('23:00', '08:00'),
+    ['23:00', '06:30']
+  );
+});
+
+test('adjustOvernight passes through valid overnight', () => {
+  assert.deepStrictEqual(
+    adjustOvernight('23:00', '05:00'),
+    ['23:00', '05:00']
+  );
+});
+
+test('adjustOvernight throws on invalid times', () => {
+  assert.throws(() => adjustOvernight('99:00', '05:00'));
+  assert.throws(() => adjustOvernight('23:00', 'aa:bb'));
+});


### PR DESCRIPTION
## Summary
- validate hh:mm strings in `toMins`
- throw error in `adjustOvernight` when invalid times are supplied
- add unit tests for valid and invalid time scenarios

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68c2d742d3788328826eb6e972cb0415