### PR TITLE
Use Supabase for next-day punches

### DIFF
--- a/test/calculate.test.js
+++ b/test/calculate.test.js
@@ -1,6 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert');
-const { adjustOvernight, toMins } = require('../src/calculate');
+const { adjustOvernight, toMins, __setNextDayFirstPunchFetcher } = require('../src/calculate');
 
 test('toMins parses valid times', () => {
   assert.strictEqual(toMins('07:30'), 450);
@@ -16,21 +16,33 @@ test('toMins rejects invalid times', () => {
   assert.ok(Number.isNaN(toMins(123)));
 });
 
-test('adjustOvernight caps times past cutoff', () => {
+test('adjustOvernight caps times past cutoff', async () => {
   assert.deepStrictEqual(
-    adjustOvernight('23:00', '08:00'),
+    await adjustOvernight('23:00', '08:00'),
     ['23:00', '06:30']
   );
 });
 
-test('adjustOvernight passes through valid overnight', () => {
+test('adjustOvernight passes through valid overnight', async () => {
   assert.deepStrictEqual(
-    adjustOvernight('23:00', '05:00'),
+    await adjustOvernight('23:00', '05:00'),
     ['23:00', '05:00']
   );
 });
 
-test('adjustOvernight throws on invalid times', () => {
-  assert.throws(() => adjustOvernight('99:00', '05:00'));
-  assert.throws(() => adjustOvernight('23:00', 'aa:bb'));
+test('adjustOvernight uses next-day punch before cutoff', async () => {
+  __setNextDayFirstPunchFetcher(async () => '05:15');
+  try {
+    assert.deepStrictEqual(
+      await adjustOvernight('23:00', '08:00', 1, '2024-01-01'),
+      ['23:00', '05:15']
+    );
+  } finally {
+    __setNextDayFirstPunchFetcher();
+  }
+});
+
+test('adjustOvernight throws on invalid times', async () => {
+  await assert.rejects(() => adjustOvernight('99:00', '05:00'));
+  await assert.rejects(() => adjustOvernight('23:00', 'aa:bb'));
 });


### PR DESCRIPTION
## Summary
- fetch first punch of following day from Supabase with error handling
- support injection of custom punch fetcher for testing
- cover next-day punch cutoff behavior in tests

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68c2d852cb948328a0b999409890cddd