### PR TITLE
feat: allow cutoff for next-day punch fetcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -7238,7 +7238,7 @@ const otInActual = pickEarliest({start: schedule.rng_ot_in_start, end: schedule.
         }
         let otOutEff = lastOutStr;
         try {
-          const borrowed = await __getNextDayFirstPunch(empId, date);
+          const borrowed = await __getNextDayFirstPunch(empId, date, 6 * 60 + 30);
           if (typeof borrowed === 'string') otOutEff = borrowed;
         } catch (e) {}
         if (otOutEff) {

--- a/test/adjustOvernight.test.js
+++ b/test/adjustOvernight.test.js
@@ -14,18 +14,25 @@ describe('adjustOvernight', () => {
   });
 
   test('uses next-day punch before cutoff', async () => {
-    __setNextDayFirstPunchFetcher(async () => '05:15');
+    const fetcher = jest.fn(async (_empId, _date, cutoff) => {
+      expect(cutoff).toBe(390);
+      return '05:15';
+    });
+    __setNextDayFirstPunchFetcher(fetcher);
     try {
       await expect(adjustOvernight('23:00', '08:00', 1, '2024-01-01')).resolves.toEqual(['23:00', '05:15']);
+      expect(fetcher).toHaveBeenCalledWith(1, '2024-01-01', 390);
     } finally {
       __setNextDayFirstPunchFetcher();
     }
   });
 
   test('defaults to cutoff when next-day punch missing', async () => {
-    __setNextDayFirstPunchFetcher(async () => null);
+    const fetcher = jest.fn(async () => null);
+    __setNextDayFirstPunchFetcher(fetcher);
     try {
       await expect(adjustOvernight('23:00', '08:00', 1, '2024-01-01')).resolves.toEqual(['23:00', '06:30']);
+      expect(fetcher).toHaveBeenCalledWith(1, '2024-01-01', 390);
     } finally {
       __setNextDayFirstPunchFetcher();
     }


### PR DESCRIPTION
## Summary
- support optional cutoff in defaultNextDayFirstPunch and document it
- pass cutoff to next-day fetcher and OT calc
- update tests to cover new cutoff parameter

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2de508cd48328931ac5da99a4da9c