### PR TITLE
Correct loan totals in payroll grand totals

### DIFF
--- a/index.html
+++ b/index.html
@@ -8255,6 +8255,7 @@ document.addEventListener('DOMContentLoaded', function(){
     var foot = document.querySelector('#payrollTotalsFoot');
     if (!tb || !foot) return;
     var t = {regHrs:0, otHrs:0, adjHrs:0, totalHrs:0, rate:0, regPay:0, otPay:0, grossPay:0, pagibig:0, philhealth:0, sss:0, loanSSS:0, loanPI:0, vale:0, valeWed:0, totalDed:0, adjAmt:0, bantay:0, netPay:0};
+    var div = Number(divisor) || 1;
     tb.querySelectorAll('tr').forEach(function(tr){
       t.regHrs   += _parse(tr.querySelector('.regHrs')?.value);
       t.otHrs    += _parse(tr.querySelector('.otHrs')?.value);
@@ -8269,8 +8270,8 @@ document.addEventListener('DOMContentLoaded', function(){
       t.pagibig  += _parse(tr.querySelector('.pagibig')?.textContent);
       t.philhealth += _parse(tr.querySelector('.philhealth')?.textContent);
       t.sss      += _parse(tr.querySelector('.sss')?.textContent);
-      t.loanSSS  += _parse(tr.querySelector('.loanSSS')?.value);
-      t.loanPI   += _parse(tr.querySelector('.loanPI')?.value);
+      t.loanSSS  += _parse(tr.querySelector('.loanSSS')?.value) / div;
+      t.loanPI   += _parse(tr.querySelector('.loanPI')?.value) / div;
       t.vale     += _parse(tr.querySelector('.vale')?.value);
       t.valeWed  += _parse(tr.querySelector('.valeWed')?.value);
       t.totalDed += _parse(tr.querySelector('.totalDed')?.textContent);


### PR DESCRIPTION
## Summary
- Divide loan SSS and Pag-ibig inputs by the payroll divisor when computing payroll grand totals
- Keep grand total deductions derived from per-row totals

## Testing
- `node <script>` manual verification that loan and deduction grand totals match per-row sums

------
https://chatgpt.com/codex/tasks/task_e_68c3781bed8883288ddb7a368f87a75e