### PR TITLE
Reorder Bantay column before Gross Pay

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,7 +268,7 @@ function safeStringify(v){
   }
 
 /* === PATCH: Bantay column width === */
-#payrollTable th:nth-child(20), #payrollTable td:nth-child(20) { width: 100px; min-width: 100px; }
+#payrollTable th:nth-child(10), #payrollTable td:nth-child(10) { width: 100px; min-width: 100px; }
 /* === END PATCH === */
 
 /* === PERF: faster layout for payroll table === */
@@ -596,10 +596,8 @@ window.addEventListener('load', dashReports);
   <style>
 
   /* Hide individual deduction columns in Payroll table (show only Total Deductions).
-     After adding the Adjustment Hrs column, the indices shift by one.
-     Hide Pagâ€‘IBIG to Wed Vale columns (cols 10â€“16). */
-  #payrollTab #payrollTable th:nth-child(11),
-  #payrollTab #payrollTable td:nth-child(11),
+     After adding the Adjustment Hrs column and moving Bantay, the indices shift by one.
+     Hide Pagâ€‘IBIG to Wed Vale columns (cols 12â€“18). */
   #payrollTab #payrollTable th:nth-child(12),
   #payrollTab #payrollTable td:nth-child(12),
   #payrollTab #payrollTable th:nth-child(13),
@@ -611,7 +609,9 @@ window.addEventListener('load', dashReports);
   #payrollTab #payrollTable th:nth-child(16),
   #payrollTab #payrollTable td:nth-child(16),
   #payrollTab #payrollTable th:nth-child(17),
-  #payrollTab #payrollTable td:nth-child(17) { display: none; }
+  #payrollTab #payrollTable td:nth-child(17),
+  #payrollTab #payrollTable th:nth-child(18),
+  #payrollTab #payrollTable td:nth-child(18) { display: none; }
 /* === PATCH: column widths for Hourly Rate, Regular Hours, OT Hours === */
 #payrollTable th, #payrollTable td { white-space: nowrap; }
 #payrollTable th:nth-child(3), #payrollTable td:nth-child(3) { width: 110px; min-width: 110px; } /* Hourly Rate */
@@ -1968,6 +1968,9 @@ window.addEventListener('load', dashReports);
          OT Pay
         </th>
         <th>
+         Bantay
+        </th>
+        <th>
          Gross Pay
         </th>
         <th>
@@ -1998,9 +2001,6 @@ window.addEventListener('load', dashReports);
          Adjustments
         </th>
         <th>
-         Bantay
-        </th>
-        <th>
          Net Pay
         </th>
        <th>
@@ -2023,6 +2023,7 @@ window.addEventListener('load', dashReports);
     <td class="num" data-col="totalHrs">0.00</td>
     <td class="num" data-col="regPay">0.00</td>
     <td class="num" data-col="otPay">0.00</td>
+    <td class="num" data-col="bantay">0.00</td>
     <td class="num" data-col="grossPay">0.00</td>
     <td class="num" data-col="pagibig">0.00</td>
     <td class="num" data-col="philhealth">0.00</td>
@@ -2033,7 +2034,6 @@ window.addEventListener('load', dashReports);
     <td class="num" data-col="valeWed">0.00</td>
     <td class="num" data-col="totalDed">0.00</td>
     <td class="num" data-col="adjAmt">0.00</td>
-    <td class="num" data-col="bantay">0.00</td>
     <td class="num" data-col="netPay">0.00</td>
     <td></td>
   </tr>
@@ -2805,6 +2805,7 @@ function renderTable(){
         <td><input class="cell otHrs" title="Non-editable in Payroll" type="number" step="0.01" value="${oH}" disabled></td>
         <td class="adjHrs num">${aH ? aH.toFixed(2) : '0.00'}</td><td class="totalHrs num">0.00</td><td class="regPay num">0.00</td>
         <td class="otPay num">0.00</td>
+        <td><input class="cell bantay" type="number" step="0.01" value="${bVal}"></td>
         <td class="grossPay num">0.00</td>
         <td class="pagibig num">0.00</td>
         <td class="philhealth num">0.00</td>
@@ -2815,7 +2816,6 @@ function renderTable(){
         <td class="valeWed num">${vW}</td>
         <td class="totalDed num">0.00</td>
         <td class="adjAmt num">0.00</td>
-        <td><input class="cell bantay" type="number" step="0.01" value="${bVal}"></td>
         <td class="netPay num">0.00</td>
         <td><button type="button" class="payslipBtn">Payslip</button></td>`;
       frag.appendChild(tr);
@@ -3473,7 +3473,7 @@ function updateContributionNote() {
 }
 document.getElementById('downloadPayrollCSV').addEventListener('click', ()=>{
   // Include Adjustments column in payroll CSV export
-  const header = ['Week Start','Week End','OT Multiplier','Divisor','ID','Name','Regular Hours','OT Hours','Hourly Rate','Regular Pay','OT Pay','Gross Pay','Pag-IBIG','PhilHealth','SSS','SSS Loan','Pag-IBIG Loan','Vale','Wed Vale','Total Deductions','Adjustments','Net Pay'];
+  const header = ['Week Start','Week End','OT Multiplier','Divisor','ID','Name','Regular Hours','OT Hours','Hourly Rate','Regular Pay','OT Pay','Bantay','Gross Pay','Pag-IBIG','PhilHealth','SSS','SSS Loan','Pag-IBIG Loan','Vale','Wed Vale','Total Deductions','Adjustments','Net Pay'];
   const rows=[header];
   const ws = weekStartEl.value||''; const we = weekEndEl.value||''; const otm = String(otMultiplierEl.value||''); const div = String(divisorEl.value||'1');
   document.querySelectorAll('#payrollTable tbody tr').forEach(tr=>{
@@ -3482,6 +3482,7 @@ document.getElementById('downloadPayrollCSV').addEventListener('click', ()=>{
     const regI = tr.querySelector('.regHrs'); const otI = tr.querySelector('.otHrs'); const rateI = tr.querySelector('.rate');
     const regPay = tr.querySelector('.regPay').textContent.trim();
     const otPay = tr.querySelector('.otPay').textContent.trim();
+    const bantayVal = tr.querySelector('.bantay').value;
     const grossPay = tr.querySelector('.grossPay').textContent.trim();
     const pagibig = tr.querySelector('.pagibig').textContent.trim();
     const philhealth = tr.querySelector('.philhealth').textContent.trim();
@@ -3491,7 +3492,7 @@ document.getElementById('downloadPayrollCSV').addEventListener('click', ()=>{
     const total = tr.querySelector('.totalDed').textContent.trim();
     const adj   = tr.querySelector('.adjAmt') ? tr.querySelector('.adjAmt').textContent.trim() : '';
     const net   = tr.querySelector('.netPay').textContent.trim();
-    rows.push([ws,we,otm,div,id,name,regI.value,otI.value,rateI.value,regPay,otPay,grossPay,pagibig,philhealth,sss,lSSS,lPI,v,vW,total,adj,net]);
+    rows.push([ws,we,otm,div,id,name,regI.value,otI.value,rateI.value,regPay,otPay,bantayVal,grossPay,pagibig,philhealth,sss,lSSS,lPI,v,vW,total,adj,net]);
   });
   const csv = rows.map(r=>r.map(s=>{
     s = String(s ?? '');
@@ -3874,9 +3875,9 @@ document.addEventListener('DOMContentLoaded', () => {
         return isNaN(num2) ? 0 : num2;
     }
       // Column index fallbacks aligned with current payrollTable structure
-      // 0:ID, 1:Name, 2:Rate, 3:RegHrs, 4:OTHrs, 5:AdjHrs, 6:TotalHrs, 7:RegPay, 8:OTPay,
-      // 9:Gross, 10:Pag-IBIG, 11:PhilHealth, 12:SSS, 13:SSS Loan, 14:Pag-IBIG Loan,
-      // 15:Vale, 16:Wed Vale, 17:Total Ded, 18:Adjustments, 19:Bantay, 20:Net Pay, 21:Payslip
+      // 0:ID, 1:Name, 2:Rate, 3:RegHrs, 4:OTHrs, 5:AdjHrs, 6:TotalHrs, 7:RegPay, 8:OTPay, 9:Bantay,
+      // 10:Gross, 11:Pag-IBIG, 12:PhilHealth, 13:SSS, 14:SSS Loan, 15:Pag-IBIG Loan,
+      // 16:Vale, 17:Wed Vale, 18:Total Ded, 19:Adjustments, 20:Net Pay, 21:Payslip
       data.rate = readNum('.rate', 2);
       data.regHrs = readNum('.regHrs', 3);
       data.otHrs = readNum('.otHrs', 4);
@@ -3884,17 +3885,17 @@ document.addEventListener('DOMContentLoaded', () => {
       data.totalHrs = readNum('.totalHrs', 6);
       data.regPay = readNum('.regPay', 7);
       data.otPay = readNum('.otPay', 8);
-      data.grossPay = readNum('.grossPay', 9);
-      data.pagibig = readNum('.pagibig', 10);
-      data.philhealth = readNum('.philhealth', 11);
-      data.sss = readNum('.sss', 12);
-      data.loanSSS = readNum('.loanSSS', 13);
-      data.loanPI = readNum('.loanPI', 14);
-      data.vale = readNum('.vale', 15);
-      data.valeWed = readNum('.valeWed', 16);
-      data.totalDed = readNum('.totalDed', 17);
-      data.adjAmt = readNum('.adjAmt', 18);
-      data.bantay = readNum('.bantay', 19);
+      data.bantay = readNum('.bantay', 9);
+      data.grossPay = readNum('.grossPay', 10);
+      data.pagibig = readNum('.pagibig', 11);
+      data.philhealth = readNum('.philhealth', 12);
+      data.sss = readNum('.sss', 13);
+      data.loanSSS = readNum('.loanSSS', 14);
+      data.loanPI = readNum('.loanPI', 15);
+      data.vale = readNum('.vale', 16);
+      data.valeWed = readNum('.valeWed', 17);
+      data.totalDed = readNum('.totalDed', 18);
+      data.adjAmt = readNum('.adjAmt', 19);
       data.netPay = readNum('.netPay', 20);
       // Capture DTR records for this employee within the selected date range. Stores an array of {date, times}
       try {
@@ -4151,19 +4152,19 @@ document.addEventListener('DOMContentLoaded', () => {
     // Mirror the payroll grid ordering, including adjustment/total hours and Bantay
     const header = [
       'ID','Name','Hourly Rate','Regular Hours','OT Hours','Adjustment Hours','Total Hours',
-      'Regular Pay','OT Pay','Gross Pay',
+      'Regular Pay','OT Pay','Bantay','Gross Pay',
       'Pag-IBIG','PhilHealth','SSS','SSS Loan','Pag-IBIG Loan','Vale','Wed Vale',
-      'Total Deductions','Adjustments','Bantay','Net Pay'
+      'Total Deductions','Adjustments','Net Pay'
     ];
     const lines = [header.join(',')];
     snap.rows.forEach(row => {
       const values = [
         row.id, row.name,
         row.rate, row.regHrs, row.otHrs, row.adjHrs, row.totalHrs,
-        row.regPay, row.otPay, row.grossPay,
+        row.regPay, row.otPay, row.bantay, row.grossPay,
         row.pagibig, row.philhealth, row.sss,
         row.loanSSS, row.loanPI, row.vale, row.valeWed,
-        row.totalDed, row.adjAmt, row.bantay, row.netPay
+        row.totalDed, row.adjAmt, row.netPay
       ];
       lines.push(values.map(v => {
         const s = String(v ?? '');
@@ -4466,9 +4467,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // Display columns similar to the live payroll grid (omit Total Deductions per request)
     const headers = [
       'ID','Name','Hourly Rate','Regular Hrs','OT Hrs','Adjustment Hrs','Total Hours',
-      'Reg Pay','OT Pay','Gross',
+      'Reg Pay','OT Pay','Bantay','Gross',
       'Pag-IBIG','PhilHealth','SSS','SSS Loan','Pag-IBIG Loan','Vale','Wed Vale',
-      'Adjustments','Bantay','Net Pay'
+      'Adjustments','Net Pay'
     ];
     headers.forEach(h => {
       const th = document.createElement('th');
@@ -4484,10 +4485,10 @@ document.addEventListener('DOMContentLoaded', () => {
     // Running grand totals (match Payroll semantics; loans are per-period shares)
     let GT = {
       regHrs:0, otHrs:0, adjHrs:0, totalHrs:0,
-      regPay:0, otPay:0, gross:0,
+      regPay:0, otPay:0, bantay:0, gross:0,
       pagibig:0, philhealth:0, sss:0,
       loanSSS:0, loanPI:0, vale:0, wedVale:0,
-      adjAmt:0, bantay:0, netPay:0
+      adjAmt:0, netPay:0
     };
     // Each employee row in the snapshot may include an adjAmt property
     // representing manual adjustments. Build the table row accordingly.
@@ -4546,10 +4547,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const vals = [
         id, r.name, rate, regHrs, otHrs, adjHrs, totalHrs,
-        regPay, otPay, gross,
+        regPay, otPay, bantay, gross,
         pagibig, philhealth, sss,
         loanSSSPer, loanPIPer, vale, wedVale,
-        adjAmt, bantay, netPay
+        adjAmt, netPay
       ];
       // Accumulate grand totals
       GT.regHrs     += regHrs;
@@ -4558,6 +4559,7 @@ document.addEventListener('DOMContentLoaded', () => {
       GT.totalHrs   += totalHrs;
       GT.regPay     += regPay;
       GT.otPay      += otPay;
+      GT.bantay     += bantay;
       GT.gross      += gross;
       GT.pagibig    += pagibig;
       GT.philhealth += philhealth;
@@ -4567,7 +4569,6 @@ document.addEventListener('DOMContentLoaded', () => {
       GT.vale       += vale;
       GT.wedVale    += wedVale;
       GT.adjAmt     += adjAmt;
-      GT.bantay     += bantay;
       GT.netPay     += netPay;
 
       vals.forEach(v => {
@@ -4603,10 +4604,10 @@ document.addEventListener('DOMContentLoaded', () => {
     ft.appendChild(label);
     const cells = [
       GT.regHrs, GT.otHrs, GT.adjHrs, GT.totalHrs,
-      GT.regPay, GT.otPay, GT.gross,
+      GT.regPay, GT.otPay, GT.bantay, GT.gross,
       GT.pagibig, GT.philhealth, GT.sss,
       GT.loanSSS, GT.loanPI, GT.vale, GT.wedVale,
-      GT.adjAmt, GT.bantay, GT.netPay
+      GT.adjAmt, GT.netPay
     ];
     cells.forEach(n => {
       const td = document.createElement('td');


### PR DESCRIPTION
## Summary
- Move Bantay column next to OT Pay and shift gross/summary totals
- Update CSS and snapshot/export logic for new Bantay index

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e "const reg=8,ot=2,rate=10,adj=5,bantay=3,otMult=1.5;const regPay=reg*rate;const otPay=ot*rate*otMult;const gross=regPay+otPay;const total=0;const net=gross-total+adj+bantay;console.log('netPay',net.toFixed(2));"`


------
https://chatgpt.com/codex/tasks/task_e_68c7aed116b48328960f1beb54d76f02