### PR TITLE
Refresh deductions table when returning to main subtab

### DIFF
--- a/index.html
+++ b/index.html
@@ -9606,6 +9606,9 @@ function updateWeekInputs(snap) {
         document.querySelectorAll('#deductionsTab .subtab-panel').forEach(panel => {
           panel.style.display = (panel.id === target) ? '' : 'none';
         });
+        if (target === 'dedMainSection' && typeof window.renderDeductionsTable === 'function') {
+          window.renderDeductionsTable();
+        }
       });
     });
     // Initialize panel visibility on page load


### PR DESCRIPTION
## Summary
- Re-render deductions data when switching back to the main deductions subtab to keep all columns, including Pag-IBIG and PhilHealth, up to date.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c802d9ba108328b16198d13ffe252e