### PR TITLE
Ensure DTR delete buttons persist after render

### DIFF
--- a/index.html
+++ b/index.html
@@ -7729,6 +7729,8 @@ function restoreData(file) {
       tr.appendChild(td);
     });
   }
+  window.ensureActionsHeader = ensureActionsHeader;
+  window.addDtrDeleteButtons = addDtrDeleteButtons;
   function patchRenderResults(){
     if(typeof renderResults !== 'function') return false;
     const original = renderResults;
@@ -10394,6 +10396,8 @@ document.addEventListener('DOMContentLoaded', async function () {
   function afterRender(){
     applyOverridesToTable();
     addDtrEditorButtons();
+    if (typeof window.ensureActionsHeader === 'function') window.ensureActionsHeader();
+    if (typeof window.addDtrDeleteButtons === 'function') window.addDtrDeleteButtons();
     recomputeDtrSummaryFromTable();
   }
 


### PR DESCRIPTION
## Summary
- expose the DTR actions helpers globally so other render hooks can reapply them
- invoke the delete-button helper during the afterRender pass to keep the Actions column populated after re-renders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8edc3cb588328bb339fa5669b6a3b