### PR TITLE
Call addDtrDeleteButtons during DTR afterRender

### DIFF
--- a/index.html
+++ b/index.html
@@ -10415,6 +10415,7 @@ document.addEventListener('DOMContentLoaded', async function () {
   function afterRender(){
     applyOverridesToTable();
     addDtrEditorButtons();
+    addDtrDeleteButtons();
     recomputeDtrSummaryFromTable();
   }
 


### PR DESCRIPTION
## Summary
- ensure the DTR afterRender hook also adds delete buttons so they stay visible after rendering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8fe4f1b5083289a59bbcf5413d994