### PR TITLE
Refresh deductions when payroll inputs change

### DIFF
--- a/index.html
+++ b/index.html
@@ -3264,6 +3264,7 @@ function attachRowEvents(){
         localStorage.setItem(LS_OT_HRS, JSON.stringify(otHours));
         localStorage.setItem(LS_RATES, JSON.stringify(payrollRates));
         saveCurrentPeriodDeductions();
+        if (typeof renderDeductionsTable === 'function') renderDeductionsTable();
         calculateRow(row);
       });
     });


### PR DESCRIPTION
## Summary
- refresh the Deductions tab after payroll-row inputs change by invoking `renderDeductionsTable()` post-save
- ensure loan and allowance edits immediately reflect in the Deductions totals without manual refresh

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d1f63613b48328accf0860ed50cd67