### PR TITLE
Fix deductions tab refresh timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -12072,11 +12072,15 @@ document.addEventListener('DOMContentLoaded', async function () {
   document.addEventListener('click', function(ev){
     const btn = ev.target && ev.target.closest && ev.target.closest('#panelPayroll .tabs .tab-btn');
     if (btn && btn.dataset && btn.dataset.tab === 'deductionsTab'){
-      if (window.__deductionsDirty && typeof window.renderDeductionsTable === 'function'){
-        try { window.renderDeductionsTable(); } catch(e){}
-      }
+      if (!window.__deductionsDirty || typeof window.renderDeductionsTable !== 'function') return;
+      const schedule = window.requestAnimationFrame ? window.requestAnimationFrame.bind(window) : function(cb){ return setTimeout(cb, 0); };
+      schedule(function(){
+        if (window.__deductionsDirty && typeof window.renderDeductionsTable === 'function' && isDeductionsVisible()){
+          try { window.renderDeductionsTable(); } catch(e){}
+        }
+      });
     }
-  }, true);
+  });
 })();
 </script>
 <script>


### PR DESCRIPTION
## Summary
- defer pending deductions refresh until after the tab becomes active
- keep the dirty guard but confirm the tab is visible before rendering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d20627814883288592037983b6280c