### PR TITLE
Ensure payroll XLS exports always include data rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -3815,7 +3815,10 @@ function updateContributionNote() {
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&#39;');
   };
-  const tableRows = rows.map((row, index) => {
+  const normalizedRows = rows.length === 1
+    ? rows.concat([new Array(header.length).fill('')])
+    : rows;
+  const tableRows = normalizedRows.map((row, index) => {
     const cellTag = index === 0 ? 'th' : 'td';
     const cells = row.map(cell => `<${cellTag}>${escapeHtml(cell)}</${cellTag}>`).join('');
     return `<tr>${cells}</tr>`;
@@ -9528,6 +9531,10 @@ document.addEventListener('DOMContentLoaded', function(){
     return isNaN(n) ? 0 : n;
   }
   function rowsToExcelHtml(rows){
+    var normalized = rows.slice();
+    if (normalized.length === 1) {
+      normalized.push(new Array(normalized[0].length).fill(''));
+    }
     var escapeHtml = function(value){
       return String(value==null?'':value)
         .replace(/&/g,'&amp;')
@@ -9536,7 +9543,7 @@ document.addEventListener('DOMContentLoaded', function(){
         .replace(/"/g,'&quot;')
         .replace(/'/g,'&#39;');
     };
-    var htmlRows = rows.map(function(row, index){
+    var htmlRows = normalized.map(function(row, index){
       var cellTag = index === 0 ? 'th' : 'td';
       var cells = row.map(function(cell){
         return '<' + cellTag + '>' + escapeHtml(cell) + '</' + cellTag + '>';
@@ -9626,7 +9633,11 @@ document.addEventListener('DOMContentLoaded', function(){
         .replace(/"/g,'&quot;')
         .replace(/'/g,'&#39;');
     };
-    var htmlRows = rows.map(function(row, index){
+    var normalized = rows.slice();
+    if (normalized.length === 1) {
+      normalized.push(new Array(normalized[0].length).fill(''));
+    }
+    var htmlRows = normalized.map(function(row, index){
       var cellTag = index === 0 ? 'th' : 'td';
       var cells = row.map(function(cell){
         return '<' + cellTag + '>' + escapeHtml(cell) + '</' + cellTag + '>';


### PR DESCRIPTION
## Summary
- ensure the payroll XLS export inserts a blank row when no employee data is present so Excel opens the sheet cleanly
- apply the same normalization to the custom net pay XLS generators used by both payroll export listeners

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d20fee65688328be86b656773cb0b7