### PR TITLE
Show combined contribution totals in master report

### DIFF
--- a/index.html
+++ b/index.html
@@ -5897,12 +5897,30 @@ rows += `<tr class="allowance">
   const renderContributionTable = (bucket, opts = {}) => {
     const data = bucket || makeContributionBucket();
     const rowClassAttr = opts.rowClass ? ` class="${opts.rowClass}"` : '';
-    const cellStyleAttr = opts.bold ? ' style="font-weight:600;"' : '';
-    const cell = (value) => `<td${cellStyleAttr}>${f2(value)}</td>`;
-    return '<table class="mr-table"><thead>'+
-      '<tr><th colspan="2">PAG-IBIG</th><th colspan="2">PHILHEALTH</th><th colspan="2">SSS</th><th rowspan="2">SSS LOAN</th><th rowspan="2">PAG-IBIG LOAN</th></tr>'+
-      '<tr><th>EE</th><th>ER</th><th>EE</th><th>ER</th><th>EE</th><th>ER</th></tr>'+
-      `</thead><tbody><tr${rowClassAttr}>${cell(data.piEE)}${cell(data.piER)}${cell(data.phEE)}${cell(data.phER)}${cell(data.sssEE)}${cell(data.sssER)}${cell(data.loanSSS)}${cell(data.loanPI)}</tr></tbody></table>`;
+    const tableHead = '<tr><th colspan="2">PAG-IBIG</th><th colspan="2">PHILHEALTH</th><th colspan="2">SSS</th><th rowspan="2">SSS LOAN</th><th rowspan="2">PAG-IBIG LOAN</th></tr>'+
+      '<tr><th>EE</th><th>ER</th><th>EE</th><th>ER</th><th>EE</th><th>ER</th></tr>';
+    const cell = (value, extraAttrs = '', { bold } = {}) => {
+      let attrs = extraAttrs || '';
+      const useBold = (bold !== undefined) ? bold : !!opts.bold;
+      if (useBold) attrs += ' style="font-weight:600;"';
+      return `<td${attrs}>${f2(value)}</td>`;
+    };
+    const rows = [`<tr${rowClassAttr}>${cell(data.piEE)}${cell(data.piER)}${cell(data.phEE)}${cell(data.phER)}${cell(data.sssEE)}${cell(data.sssER)}${cell(data.loanSSS)}${cell(data.loanPI)}</tr>`];
+    let foot = '';
+    if (opts.combineShares) {
+      const combinedBold = opts.combineBold !== undefined ? opts.combineBold : true;
+      const totalRowClassAttr = opts.combineRowClass ? ` class="${opts.combineRowClass}"` : '';
+      const label = opts.combineLabel != null ? opts.combineLabel : 'Total (Employee + Employer)';
+      const totalCells = [
+        cell(data.piEE + data.piER, ' colspan="2"', { bold: combinedBold }),
+        cell(data.phEE + data.phER, ' colspan="2"', { bold: combinedBold }),
+        cell(data.sssEE + data.sssER, ' colspan="2"', { bold: combinedBold }),
+        cell(data.loanSSS, '', { bold: combinedBold }),
+        cell(data.loanPI, '', { bold: combinedBold })
+      ].join('');
+      foot = `<tfoot><tr><td colspan="8" style="font-weight:600;text-align:left;">${safe(label)}</td></tr><tr${totalRowClassAttr}>${totalCells}</tr></tfoot>`;
+    }
+    return `<table class="mr-table"><thead>${tableHead}</thead><tbody>${rows.join('')}</tbody>${foot}</table>`;
   };
 
   function getPayrollRange(){
@@ -6202,7 +6220,7 @@ rows += `<tr class="allowance">
     if (orderedCompanies.length){
       html += '<div class="mr-section mr-grand-contributions">';
       html += '<h4>GRAND TOTAL - CONTRIBUTIONS</h4>';
-      html += renderContributionTable(overallBucket, { bold: true });
+      html += renderContributionTable(overallBucket, { bold: true, combineShares: true, combineLabel: 'TOTAL CONTRIBUTIONS (Employee + Employer)' });
       html += '</div>';
     }
 


### PR DESCRIPTION
## Summary
- extend the master report contribution table renderer so it can optionally show combined employee+employer totals
- update the "Grand Total - Contributions" block to display the summed contributions for each benefit type

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d21fc296cc832893ea85d1bea20cca