### PR TITLE
Add employer share to SSS contributions table

### DIFF
--- a/index.html
+++ b/index.html
@@ -2172,7 +2172,7 @@ window.addEventListener('load', dashReports);
        Export CSV
       </button>
       <label>
-       Import CSV (min,max,employeeShare)
+       Import CSV (min,max,employeeShare,employerShare)
        <br/>
        <input accept=".csv,text/csv" id="importSss" type="file"/>
       </label>
@@ -2190,6 +2190,9 @@ window.addEventListener('load', dashReports);
          Employee Share (â‚±)
         </th>
         <th>
+         Employer Share (â‚±)
+        </th>
+        <th>
          Actions
         </th>
        </tr>
@@ -2202,7 +2205,7 @@ window.addEventListener('load', dashReports);
       <i>
        min &le; income &le; max
       </i>
-      and use the Employee Share.
+      and use the Employee and Employer Shares.
      </div>
     <!-- Editable Pagâ€‘IBIG and PhilHealth tables (employee rates).  Each table allows
          defining income ranges and the corresponding employee rate (as a decimal).
@@ -2421,78 +2424,88 @@ if (isNaN(pagibigRate)) pagibigRate = 0.02;
 let philhealthRate = parseFloat(localStorage.getItem(LS_PHILHEALTH_RATE) ?? '0.025');
 if (isNaN(philhealthRate)) philhealthRate = 0.025;
 const SSS_SEED_2025 = [
-  [1, 5249.99, 250],
-  [5250, 5749.99, 275],
-  [5750, 6249.99, 300],
-  [6250, 6749.99, 325],
-  [6750, 7249.99, 350],
-  [7250, 7749.99, 375],
-  [7750, 8249.99, 400],
-  [8250, 8749.99, 425],
-  [8750, 9249.99, 450],
-  [9250, 9749.99, 475],
-  [9750, 10249.99, 500],
-  [10250, 10749.99, 525],
-  [10750, 11249.99, 550],
-  [11250, 11749.99, 575],
-  [11750, 12249.99, 600],
-  [12250, 12749.99, 625],
-  [12750, 13249.99, 650],
-  [13250, 13749.99, 675],
-  [13750, 14249.99, 700],
-  [14250, 14749.99, 725],
-  [14750, 15249.99, 750],
-  [15250, 15749.99, 775],
-  [15750, 16249.99, 800],
-  [16250, 16749.99, 825],
-  [16750, 17249.99, 850],
-  [17250, 17749.99, 875],
-  [17750, 18249.99, 900],
-  [18250, 18749.99, 925],
-  [18750, 19249.99, 950],
-  [19250, 19749.99, 975],
-  [19750, 20249.99, 1000],
-  [20250, 20749.99, 1025],
-  [20750, 21249.99, 1050],
-  [21250, 21749.99, 1075],
-  [21750, 22249.99, 1100],
-  [22250, 22749.99, 1125],
-  [22750, 23249.99, 1150],
-  [23250, 23749.99, 1175],
-  [23750, 24249.99, 1200],
-  [24250, 24749.99, 1225],
-  [24750, 25249.99, 1250],
-  [25250, 25749.99, 1275],
-  [25750, 26249.99, 1300],
-  [26250, 26749.99, 1325],
-  [26750, 27249.99, 1350],
-  [27250, 27749.99, 1375],
-  [27750, 28249.99, 1400],
-  [28250, 28749.99, 1425],
-  [28750, 29249.99, 1450],
-  [29250, 29749.99, 1475],
-  [29750, 30249.99, 1500],
-  [30250, 30749.99, 1525],
-  [30750, 31249.99, 1550],
-  [31250, 31749.99, 1575],
-  [31750, 32249.99, 1600],
-  [32250, 32749.99, 1625],
-  [32750, 33249.99, 1650],
-  [33250, 33749.99, 1675],
-  [33750, 34249.99, 1700],
-  [34250, 34749.99, 1725],
-  [34750, 100000000, 1750]
+  [1, 5249.99, 250, 250],
+  [5250, 5749.99, 275, 275],
+  [5750, 6249.99, 300, 300],
+  [6250, 6749.99, 325, 325],
+  [6750, 7249.99, 350, 350],
+  [7250, 7749.99, 375, 375],
+  [7750, 8249.99, 400, 400],
+  [8250, 8749.99, 425, 425],
+  [8750, 9249.99, 450, 450],
+  [9250, 9749.99, 475, 475],
+  [9750, 10249.99, 500, 500],
+  [10250, 10749.99, 525, 525],
+  [10750, 11249.99, 550, 550],
+  [11250, 11749.99, 575, 575],
+  [11750, 12249.99, 600, 600],
+  [12250, 12749.99, 625, 625],
+  [12750, 13249.99, 650, 650],
+  [13250, 13749.99, 675, 675],
+  [13750, 14249.99, 700, 700],
+  [14250, 14749.99, 725, 725],
+  [14750, 15249.99, 750, 750],
+  [15250, 15749.99, 775, 775],
+  [15750, 16249.99, 800, 800],
+  [16250, 16749.99, 825, 825],
+  [16750, 17249.99, 850, 850],
+  [17250, 17749.99, 875, 875],
+  [17750, 18249.99, 900, 900],
+  [18250, 18749.99, 925, 925],
+  [18750, 19249.99, 950, 950],
+  [19250, 19749.99, 975, 975],
+  [19750, 20249.99, 1000, 1000],
+  [20250, 20749.99, 1025, 1025],
+  [20750, 21249.99, 1050, 1050],
+  [21250, 21749.99, 1075, 1075],
+  [21750, 22249.99, 1100, 1100],
+  [22250, 22749.99, 1125, 1125],
+  [22750, 23249.99, 1150, 1150],
+  [23250, 23749.99, 1175, 1175],
+  [23750, 24249.99, 1200, 1200],
+  [24250, 24749.99, 1225, 1225],
+  [24750, 25249.99, 1250, 1250],
+  [25250, 25749.99, 1275, 1275],
+  [25750, 26249.99, 1300, 1300],
+  [26250, 26749.99, 1325, 1325],
+  [26750, 27249.99, 1350, 1350],
+  [27250, 27749.99, 1375, 1375],
+  [27750, 28249.99, 1400, 1400],
+  [28250, 28749.99, 1425, 1425],
+  [28750, 29249.99, 1450, 1450],
+  [29250, 29749.99, 1475, 1475],
+  [29750, 30249.99, 1500, 1500],
+  [30250, 30749.99, 1525, 1525],
+  [30750, 31249.99, 1550, 1550],
+  [31250, 31749.99, 1575, 1575],
+  [31750, 32249.99, 1600, 1600],
+  [32250, 32749.99, 1625, 1625],
+  [32750, 33249.99, 1650, 1650],
+  [33250, 33749.99, 1675, 1675],
+  [33750, 34249.99, 1700, 1700],
+  [34250, 34749.99, 1725, 1725],
+  [34750, 100000000, 1750, 1750]
 ];
 
 function ensureSeededSSS() {
   try {
     const cur = JSON.parse(localStorage.getItem(LS_SSS_TABLE) || '[]');
     if (!Array.isArray(cur) || cur.length === 0) {
-      const mapped = SSS_SEED_2025.map(r=>({min:r[0], max:r[1], employee:r[2]}));
+      const mapped = SSS_SEED_2025.map(r=>({min:r[0], max:r[1], employee:r[2], employer: (typeof r[3] !== 'undefined' ? r[3] : r[2])}));
       localStorage.setItem(LS_SSS_TABLE, JSON.stringify(mapped));
+    } else {
+      const normalized = cur.map(row => {
+        const min = Number(row && typeof row.min !== 'undefined' ? row.min : 0) || 0;
+        const max = Number(row && typeof row.max !== 'undefined' ? row.max : 0) || 0;
+        const employee = Number(row && typeof row.employee !== 'undefined' ? row.employee : 0) || 0;
+        const employerRaw = Number(row && typeof row.employer !== 'undefined' ? row.employer : employee);
+        const employer = Number.isFinite(employerRaw) ? employerRaw : employee;
+        return { min, max, employee, employer };
+      });
+      localStorage.setItem(LS_SSS_TABLE, JSON.stringify(normalized));
     }
   } catch (e) {
-    const mapped = SSS_SEED_2025.map(r=>({min:r[0], max:r[1], employee:r[2]}));
+    const mapped = SSS_SEED_2025.map(r=>({min:r[0], max:r[1], employee:r[2], employer: (typeof r[3] !== 'undefined' ? r[3] : r[2])}));
     localStorage.setItem(LS_SSS_TABLE, JSON.stringify(mapped));
   }
 }
@@ -2818,12 +2831,26 @@ function getSssTable(){
   try { arr = JSON.parse(localStorage.getItem(LS_SSS_TABLE) || '[]'); }
   catch(e){ arr = []; }
   if (!Array.isArray(arr)) arr = [];
-  arr = arr.map(r=>({min:Number(r.min)||0, max:Number(r.max)||0, employee:Number(r.employee)||0}))
-           .sort((a,b)=> a.min - b.min);
+  arr = arr.map(r=>{
+    const min = Number(r && typeof r.min !== 'undefined' ? r.min : 0) || 0;
+    const max = Number(r && typeof r.max !== 'undefined' ? r.max : 0) || 0;
+    const employee = Number(r && typeof r.employee !== 'undefined' ? r.employee : 0) || 0;
+    const employerRaw = Number(r && typeof r.employer !== 'undefined' ? r.employer : employee);
+    const employer = Number.isFinite(employerRaw) ? employerRaw : employee;
+    return {min, max, employee, employer};
+  }).sort((a,b)=> a.min - b.min);
   return arr;
 }
 function setSssTable(rows){
-  localStorage.setItem(LS_SSS_TABLE, JSON.stringify(rows));
+  const clean = Array.isArray(rows) ? rows.map(r => {
+    const min = Number(r && typeof r.min !== 'undefined' ? r.min : 0) || 0;
+    const max = Number(r && typeof r.max !== 'undefined' ? r.max : 0) || 0;
+    const employee = Number(r && typeof r.employee !== 'undefined' ? r.employee : 0) || 0;
+    const employerRaw = Number(r && typeof r.employer !== 'undefined' ? r.employer : employee);
+    const employer = Number.isFinite(employerRaw) ? employerRaw : employee;
+    return { min, max, employee, employer };
+  }) : [];
+  localStorage.setItem(LS_SSS_TABLE, JSON.stringify(clean));
 }
 
 function renderDeductionsTable(){
@@ -3317,14 +3344,17 @@ function renderSssTable(){
       <td><input type="number" step="0.01" class="cell sssMin" value="${r.min}"></td>
       <td><input type="number" step="0.01" class="cell sssMax" value="${r.max}"></td>
       <td><input type="number" step="0.01" class="cell sssEmp" value="${r.employee}"></td>
+      <td><input type="number" step="0.01" class="cell sssEr" value="${r.employer}"></td>
       <td><button class="delRow">Delete</button></td>`;
     tbodyS.appendChild(tr);
     const minI = tr.querySelector('.sssMin');
     const maxI = tr.querySelector('.sssMax');
     const empI = tr.querySelector('.sssEmp');
-    minI.addEventListener('input', ()=>{ updateRow(i, minI, maxI, empI); });
-    maxI.addEventListener('input', ()=>{ updateRow(i, minI, maxI, empI); });
-    empI.addEventListener('input', ()=>{ updateRow(i, minI, maxI, empI); });
+    const erI = tr.querySelector('.sssEr');
+    minI.addEventListener('input', ()=>{ updateRow(i, minI, maxI, empI, erI); });
+    maxI.addEventListener('input', ()=>{ updateRow(i, minI, maxI, empI, erI); });
+    empI.addEventListener('input', ()=>{ updateRow(i, minI, maxI, empI, erI); });
+    if (erI) erI.addEventListener('input', ()=>{ updateRow(i, minI, maxI, empI, erI); });
     tr.querySelector('.delRow').addEventListener('click', ()=>{
       const cur = getSssTable();
       cur.splice(i,1);
@@ -3334,19 +3364,24 @@ function renderSssTable(){
     });
   });
 }
-function updateRow(i, minI, maxI, empI){
+function updateRow(i, minI, maxI, empI, erI){
   const cur = getSssTable();
-  cur[i] = {min:Number(minI.value)||0, max:Number(maxI.value)||0, employee:Number(empI.value)||0};
+  const minVal = Number(minI && typeof minI.value !== 'undefined' ? minI.value : 0) || 0;
+  const maxVal = Number(maxI && typeof maxI.value !== 'undefined' ? maxI.value : 0) || 0;
+  const employeeVal = Number(empI && typeof empI.value !== 'undefined' ? empI.value : 0) || 0;
+  let employerVal = Number(erI && typeof erI.value !== 'undefined' ? erI.value : employeeVal);
+  if (!Number.isFinite(employerVal)) employerVal = employeeVal;
+  cur[i] = {min:minVal, max:maxVal, employee:employeeVal, employer:employerVal};
   setSssTable(cur);
   calculateAll();
 }
 
 document.getElementById('addSssRow').addEventListener('click', ()=>{
-  const cur = getSssTable(); cur.push({min:0,max:0,employee:0}); setSssTable(cur); renderSssTable();
+  const cur = getSssTable(); cur.push({min:0,max:0,employee:0, employer:0}); setSssTable(cur); renderSssTable();
 });
 document.getElementById('resetSss').addEventListener('click', ()=>{
   if(confirm('Reset SSS table to 2025 defaults?')){
-    const mapped = SSS_SEED_2025.map(r=>({min:r[0], max:r[1], employee:r[2]}));
+    const mapped = SSS_SEED_2025.map(r=>({min:r[0], max:r[1], employee:r[2], employer: (typeof r[3] !== 'undefined' ? r[3] : r[2])}));
     setSssTable(mapped);
     renderSssTable();
     calculateAll();
@@ -3357,7 +3392,7 @@ document.getElementById('clearSss').addEventListener('click', ()=>{
 });
 document.getElementById('exportSss').addEventListener('click', ()=>{
   const rows = getSssTable();
-  const csv = ['min,max,employeeShare'].concat(rows.map(r=>[r.min,r.max,r.employee].join(','))).join('\n');
+  const csv = ['min,max,employeeShare,employerShare'].concat(rows.map(r=>[r.min,r.max,r.employee,r.employer].join(','))).join('\n');
   const blob = new Blob([csv], {type:'text/csv'}); const url = URL.createObjectURL(blob);
   const a = document.createElement('a'); a.href=url; a.download='sss_table.csv'; document.body.appendChild(a); a.click(); a.remove();
 });
@@ -3371,7 +3406,18 @@ document.getElementById('importSss').addEventListener('change', ev=>{
     for(let i=0;i<lines.length;i++){ const line = lines[i].trim();
       if(i===0 && /min/i.test(line) && /max/i.test(line)) continue;
       const p = line.split(',');
-      if(p.length>=3) out.push({min:Number(p[0])||0,max:Number(p[1])||0,employee:Number(p[2])||0});
+      if(p.length>=3) {
+        const min = Number(p[0])||0;
+        const max = Number(p[1])||0;
+        const employee = Number(p[2])||0;
+        let employer = NaN;
+        if (p.length >= 4) {
+          const parsed = Number(p[3]);
+          if (Number.isFinite(parsed)) employer = parsed;
+        }
+        if (!Number.isFinite(employer)) employer = employee;
+        out.push({min, max, employee, employer});
+      }
     }
     setSssTable(out); renderSssTable(); calculateAll();
   };
@@ -3540,6 +3586,20 @@ function sssShareByMonthly(monthly){
   if(monthly <= rows[0].min) return Number(rows[0].employee)||0;
   for(const r of rows){ if(monthly >= r.min && monthly <= r.max) return Number(r.employee)||0; }
   return Number(rows[rows.length-1].employee)||0;
+}
+
+function sssEmployerShareByMonthly(monthly){
+  const rows = getSssTable();
+  if(rows.length===0) return 0;
+  rows.sort((a,b)=>a.min-b.min);
+  if(monthly <= rows[0].min) return Number(rows[0].employer ?? rows[0].employee) || 0;
+  for(const r of rows){
+    if(monthly >= r.min && monthly <= r.max){
+      return Number(r.employer ?? r.employee) || 0;
+    }
+  }
+  const last = rows[rows.length-1];
+  return Number(last.employer ?? last.employee) || 0;
 }
 
 // Determine Pagâ€‘IBIG contribution rate based on the monthly income.  Uses the
@@ -5984,13 +6044,15 @@ rows += `<tr class="allowance">
         const piRate = (typeof pagibigRateByMonthly==='function') ? pagibigRateByMonthly(monthly) : 0;
         const phRate = (typeof philhealthRateByMonthly==='function') ? philhealthRateByMonthly(monthly) : 0;
         const sssFull = (typeof sssShareByMonthly==='function') ? sssShareByMonthly(monthly) : 0;
+        const sssEmployerFull = (typeof sssEmployerShareByMonthly==='function') ? sssEmployerShareByMonthly(monthly) : sssFull;
         const flags = flagsAll[id] || {};
         const pi = (flags.pagibig===false) ? 0 : +(regPay * piRate).toFixed(2);
         const ph = (flags.philhealth===false) ? 0 : +(regPay * phRate).toFixed(2);
-        const sss = (flags.sss===false) ? 0 : +(sssFull/div).toFixed(2);
+        const sssEE = (flags.sss===false) ? 0 : +(sssFull/div).toFixed(2);
+        const sssER = (flags.sss===false) ? 0 : +(sssEmployerFull/div).toFixed(2);
         bucket.piEE += pi; bucket.piER += pi;
         bucket.phEE += ph; bucket.phER += ph;
-        bucket.sssEE += sss; bucket.sssER += sss;
+        bucket.sssEE += sssEE; bucket.sssER += sssER;
         bucket.loanSSS += +(num(lSSS[id]) / div).toFixed(2);
         bucket.loanPI  += +(num(lPI[id])  / div).toFixed(2);
       });


### PR DESCRIPTION
## Summary
- add an Employer Share column to the SSS range table and CSV helpers
- persist employer-share values alongside employee-share defaults and seeded data
- include employer share in contribution summaries with a new lookup helper

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d24803f548832894c4e4d77545e6f3