### PR TITLE
Fix payroll history Excel export to recalc period data

### DIFF
--- a/index.html
+++ b/index.html
@@ -5856,11 +5856,44 @@ rows += `<tr class="allowance">
       try{
         const ws = document.getElementById('weekStart');
         const we = document.getElementById('weekEnd');
-        const prevS = ws && ws.value; const prevE = we && we.value;
-        if (ws) ws.value = from || prevS; if (we) we.value = to || prevE;
-        try{ if (typeof calculatePayrollFromResultsTable==='function') calculatePayrollFromResultsTable(); else if (typeof calculatePayrollFromRecords==='function') calculatePayrollFromRecords(); }catch(e){}
-        try{ if (typeof window.rebuildReports==='function') window.rebuildReports(); }catch(e){}
-        setTimeout(function(){ try{ exportExcelAllTabs(); } finally { try{ if (ws) ws.value = prevS; if (we) we.value = prevE; if (typeof window.rebuildReports==='function') window.rebuildReports(); }catch(e){} } }, 300);
+        const prevS = ws && ws.value;
+        const prevE = we && we.value;
+        const targetS = from || prevS;
+        const targetE = to || prevE;
+        const changed = (targetS !== prevS) || (targetE !== prevE);
+
+        function recalcForActiveRange(){
+          try{ if (typeof syncPeriodScopedData === 'function') syncPeriodScopedData(); }catch(e){}
+          try{
+            if (typeof calculatePayrollFromResultsTable === 'function') {
+              calculatePayrollFromResultsTable();
+            } else if (typeof calculatePayrollFromRecords === 'function') {
+              calculatePayrollFromRecords();
+            }
+          }catch(e){}
+          try{ if (typeof checkAndToggleEditState === 'function') checkAndToggleEditState(); }catch(e){}
+          try{ if (typeof window.rebuildReports === 'function') window.rebuildReports(); }catch(e){}
+        }
+
+        if (ws) ws.value = targetS;
+        if (we) we.value = targetE;
+
+        recalcForActiveRange();
+
+        setTimeout(function(){
+          try{
+            exportExcelAllTabs();
+          } finally {
+            if (ws) ws.value = prevS;
+            if (we) we.value = prevE;
+            if (changed) {
+              recalcForActiveRange();
+            } else {
+              try{ if (typeof checkAndToggleEditState === 'function') checkAndToggleEditState(); }catch(e){}
+              try{ if (typeof window.rebuildReports === 'function') window.rebuildReports(); }catch(e){}
+            }
+          }
+        }, 300);
       }catch(e){ console.warn('Export for range failed', e); }
     }
     try { window.exportExcelAllTabsForRange = exportExcelAllTabsForRange; } catch(e){}


### PR DESCRIPTION
## Summary
- load the target period's scoped data before generating the Payroll History "Excel (All Tabs)" workbook so the export uses the correct values
- restore the previous payroll period after exporting by re-running the usual recalculation hooks for the prior dates

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d25b458d848328a51eba93d11f7fdc