### PR TITLE
Enhance payslip outline for clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -426,7 +426,7 @@ html, body { width: 8.5in; height: 11in; margin: 0; -webkit-print-color-adjust: 
 body{font-family:Arial,Helvetica,sans-serif;margin:0;padding:0 0.1in;}
 .payslip-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:0.03in;}
 .payslip-grid.single{grid-template-columns:repeat(1,1fr);max-width:3in;margin:0 auto;}
-.payslip{box-sizing:border-box;padding:0.06in;border:1px solid #e2e8f0;height:2.6in;overflow:hidden;border-radius:3px;background:#fff;}
+.payslip{box-sizing:border-box;padding:0.06in;border:1px solid #475569;height:2.6in;overflow:hidden;border-radius:3px;background:#fff;box-shadow:0 0 0 1px rgba(15,23,42,0.2);}
 table{border-collapse:collapse;width:100%;font-size:8.5px;}
 th,td{border:1px solid #e2e8f0;padding:1px;text-align:left;}
 th{background:#f1f5f9;}
@@ -458,7 +458,7 @@ html, body { width: 8.5in; height: 11in; margin: 0; -webkit-print-color-adjust: 
 body{font-family:Arial,Helvetica,sans-serif;margin:0;padding:0 0.1in;}
 .payslip-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:0.03in;}
 .payslip-grid.single{grid-template-columns:repeat(1,1fr);max-width:3in;margin:0 auto;}
-.payslip{box-sizing:border-box;padding:0.06in;border:1px solid #e2e8f0;height:2.6in;overflow:hidden;border-radius:3px;background:#fff;}
+.payslip{box-sizing:border-box;padding:0.06in;border:1px solid #475569;height:2.6in;overflow:hidden;border-radius:3px;background:#fff;box-shadow:0 0 0 1px rgba(15,23,42,0.2);}
 table{border-collapse:collapse;width:100%;font-size:8.5px;}
 th,td{border:1px solid #e2e8f0;padding:1px;text-align:left;}
 th{background:#f1f5f9;}
@@ -10025,7 +10025,7 @@ html, body { width: 8.5in; height: 11in; margin: 0; -webkit-print-color-adjust: 
 body{font-family:Arial,Helvetica,sans-serif;margin:0;padding:0 0.1in;}
 .payslip-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:0.03in;}
 .payslip-grid.single{grid-template-columns:repeat(1,1fr);max-width:3in;margin:0 auto;}
-.payslip{box-sizing:border-box;padding:0.06in;border:1px solid #e2e8f0;height:2.6in;overflow:hidden;border-radius:3px;background:#fff;}
+.payslip{box-sizing:border-box;padding:0.06in;border:1px solid #475569;height:2.6in;overflow:hidden;border-radius:3px;background:#fff;box-shadow:0 0 0 1px rgba(15,23,42,0.2);}
 table{border-collapse:collapse;width:100%;font-size:8.5px;}
 th,td{border:1px solid #e2e8f0;padding:1px;text-align:left;}
 th{background:#f1f5f9;}


### PR DESCRIPTION
## Summary
- darken the payslip card border and add a subtle outline so each slip is easier to distinguish
- keep the updated styling available in both bulk and single payslip print views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d384f352bc8328a0e9978e69432732