### PR TITLE
Fix payroll Excel footer alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -5929,7 +5929,18 @@ rows += `<tr class="allowance">
           const head = [Array.from(clone.querySelectorAll('thead th')).map(th=> (th.textContent||'').trim())];
           const body = Array.from(clone.querySelectorAll('tbody tr')).map(tr=> Array.from(tr.querySelectorAll('td')).map(td=> (td.textContent||'').trim()));
           const foot = [];
-          const tfr = clone.querySelector('tfoot tr'); if (tfr){ foot.push(Array.from(tfr.querySelectorAll('td')).map(td=> (td.textContent||'').trim())); }
+          const tfr = clone.querySelector('tfoot tr');
+          if (tfr) {
+            const cells = Array.from(tfr.querySelectorAll('td'));
+            const row = [];
+            cells.forEach(td => {
+              const text = (td.textContent || '').trim();
+              const span = Number(td.getAttribute('colspan') || td.colSpan || 1);
+              row.push(text);
+              for (let i = 1; i < span; i++) row.push('');
+            });
+            foot.push(row);
+          }
           const aoa = head.concat(body).concat(foot);
           XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet(aoa), 'Payroll');
         }catch(e){}


### PR DESCRIPTION
## Summary
- expand the payroll Excel export footer handling to respect table cell colspans
- ensure the Grand Total label occupies both ID and Name columns so numeric totals stay aligned in Excel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4a7bbec2083288827f8e37b937c44