### PR TITLE
Add reports data to Excel all tabs export

### DIFF
--- a/index.html
+++ b/index.html
@@ -6326,24 +6326,38 @@ rows += `<tr class="allowance">
         const { from, to } = detailBundle;
         const wb = XLSX.utils.book_new();
 
+        const safeSheetName = (name) => {
+          const raw = (name == null) ? '' : String(name);
+          const cleaned = raw.replace(/[\/*?:\[\]]/g, ' ').trim();
+          return cleaned ? cleaned.slice(0, 31) : 'Sheet';
+        };
+
+        try {
+          const detailedRows = Array.isArray(detailBundle.rows) ? detailBundle.rows : null;
+          if (detailedRows && detailedRows.length){
+            const detailSheet = XLSX.utils.aoa_to_sheet(detailedRows);
+            XLSX.utils.book_append_sheet(wb, detailSheet, safeSheetName('Detailed Report'));
+          }
+        } catch(e){ console.warn('Failed to build Detailed Reports sheet', e); }
+
         try {
           const dtrAoA = buildDtrAoA();
           if (dtrAoA && dtrAoA.length){
-            XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet(dtrAoA), 'DTR');
+            XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet(dtrAoA), safeSheetName('DTR'));
           }
         } catch(e){ console.warn('Failed to build DTR sheet', e); }
 
         try {
           const payrollAoA = await buildPayrollAoA();
           if (payrollAoA && payrollAoA.length){
-            XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet(payrollAoA), 'Payroll');
+            XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet(payrollAoA), safeSheetName('Payroll'));
           }
         } catch(e){ console.warn('Failed to build Payroll sheet', e); }
 
         try {
           const masterAoA = buildMasterReportAoA();
           if (masterAoA && masterAoA.length){
-            XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet(masterAoA), 'Master Report');
+            XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet(masterAoA), safeSheetName('Master Report'));
           }
         } catch(e){ console.warn('Failed to build Master Report sheet', e); }
 


### PR DESCRIPTION
## Summary
- add the detailed reports rows that power the CSV All export as a worksheet in the Excel (All Tabs) workbook
- sanitize worksheet names when appending them to the Excel export

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4f74733988328ae166b0b1186d4c8