### PR TITLE
Remove remote DTR alert banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -1685,11 +1685,6 @@ window.addEventListener('load', dashReports);
    <div class="note">
     Regular hours computed per schedule segments. Grace applies to AM/PM in. OT detected after PM out reference.
    </div>
-   <!-- Alert to display when there is no remote DTR data and no local DTR data.  This
-        banner is hidden by default and shown via showRemoteDtrAlert() -->
-   <div id="remoteDtrAlert" style="display:none;margin:8px 0;padding:10px;border:1px solid #facc15;background:#fef9c3;color:#713f12;border-radius:6px;font-weight:600;">
-     âš  No remote DTR data found. Import a .DAT/.TXT file on this device to populate cloud data.
-   </div>
    <!-- Wrap the results table in a scrollable container so horizontal overflow
         is always visible. Without this wrapper some layouts (especially when
         embedding this page in an iframe or within a limited-width container)


### PR DESCRIPTION
## Summary
- remove the remote DTR alert banner from the DTR panel

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da19eff7948328bfedb88ef6f22e8d