### PR TITLE
Remove payroll contribution helper note

### DIFF
--- a/index.html
+++ b/index.html
@@ -2134,11 +2134,6 @@ window.addEventListener('load', dashReports);
        Print Payslips
       </button>
      </div>
-     <!-- Contribution formula note with dynamic rates updated via script -->
-     <div id="contribNote" class="section note">
-      Pag-IBIG = Regular Pay × 2% (not divided), PhilHealth = Regular Pay × 2.5% (not divided),
-    SSS = (Employee Share by Monthly Income) ÷ Divisor. SSS Loan and Pag‑IBIG Loan are divided by the Divisor. Vales are manual (not divided).
-     </div>
      <table id="payrollTable">
       <thead>
        <tr>


### PR DESCRIPTION
## Summary
- remove the contribution helper note from the payroll tab so the descriptive text no longer appears under the controls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da1a3ebdd08328a5a6ac70de11c5f8