### PR TITLE
Fix Supabase realtime subscribe error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,8 +204,11 @@ if (!window.__kvSubscribed) {
           console.warn('Supabase realtime sync failed', err);
         }
       })
-      .subscribe()
-      .catch((err) => console.warn('Supabase channel subscribe failed', err));
+      .subscribe((status) => {
+        if (status === 'CHANNEL_ERROR') {
+          console.warn('Supabase channel subscribe failed');
+        }
+      });
     if (!window.__kvUnloadCleanup) {
       window.addEventListener('beforeunload', () => {
         try {


### PR DESCRIPTION
## Summary
- replace the unsupported promise-style catch on Supabase channel.subscribe with status handling
- log a warning if the realtime channel transitions into the CHANNEL_ERROR state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da278cd00c8328adaef520ab88c18d