### PR TITLE
Fix Excel export grand total alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -4300,9 +4300,14 @@ document.addEventListener('DOMContentLoaded', function(){
 
     ['thead','tbody','tfoot'].forEach(section => {
       clone.querySelectorAll(section + ' tr').forEach(tr => {
-        const cells = Array.from(tr.children).map(cell => {
+        const cells = [];
+        Array.from(tr.children).forEach(cell => {
           const text = (cell.textContent || '').trim();
-          return text;
+          const span = parseInt(cell.getAttribute('colspan'), 10) || 1;
+          cells.push(text);
+          for (let i = 1; i < span; i += 1) {
+            cells.push('');
+          }
         });
         rows.push(cells);
       });


### PR DESCRIPTION
## Summary
- account for table column spans when generating the Print Report Excel rows so grand totals align with other columns

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dde46cb8a8832885c10b4eeee0eb45