### PR TITLE
Fix master report grand total contributions

### DIFF
--- a/index.html
+++ b/index.html
@@ -6716,9 +6716,12 @@ rows += `<tr class="allowance">
     const cell = (value) => `<td${cellStyleAttr}>${f2(value)}</td>`;
     const toNum = (v) => Number(v || 0);
     if (opts.combineEEER) {
-      const piTotal = toNum(data.piEE) + toNum(data.piER);
-      const phTotal = toNum(data.phEE) + toNum(data.phER);
-      const sssTotal = toNum(data.sssEE) + toNum(data.sssER);
+      // Per request: the combined "Grand Total - Contributions" row should only
+      // reflect the employee share of each contribution. Employer shares remain
+      // visible in the per-company tables where both columns are shown.
+      const piTotal = toNum(data.piEE);
+      const phTotal = toNum(data.phEE);
+      const sssTotal = toNum(data.sssEE);
       return '<table class="mr-table mr-contrib-table"><thead>'+
         '<tr><th>PAG-IBIG</th><th>PHILHEALTH</th><th>SSS</th><th>SSS LOAN</th><th>PAG-IBIG LOAN</th></tr>'+
         `</thead><tbody><tr${rowClassAttr}>${cell(piTotal)}${cell(phTotal)}${cell(sssTotal)}${cell(data.loanSSS)}${cell(data.loanPI)}</tr></tbody></table>`;


### PR DESCRIPTION
## Summary
- update the master report contribution summary to only total the employee share when combining EE and ER amounts
- leave employer shares visible on the per-company contribution tables

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de0ebdf91c83288c61f5985fc49a63