### PR TITLE
Update printed company name to Edifice Group Corp & Portafolio Interiors Inc.

### DIFF
--- a/index.html
+++ b/index.html
@@ -900,10 +900,41 @@ function injectPrintOrientation(html, orientation){
   }
   return html + styleTag;
 }
+function normalizePrintCompanyName(name){
+  var raw = String(name || '').trim();
+  var fullName = 'Edifice Group Corp & Portafolio Interiors Inc.';
+  if (!raw) return fullName;
+  if (/^payrollpro$/i.test(raw)) return fullName;
+  if (/^edifice$/i.test(raw) || /^edifice group corp\.?$/i.test(raw)) return fullName;
+  if (/^portafolio$/i.test(raw) || /^portafolio interiors inc\.?$/i.test(raw)) return fullName;
+  if (/^edifice\s*&\s*portafolio$/i.test(raw)) return fullName;
+  return raw;
+}
+function injectPrintHeaderStyle(html){
+  var rule = [
+    '.report-header, .payslip-header, .hdr, .header-lines, .proj-title, .mr-project-title{',
+    'text-align:center !important;',
+    'align-items:center !important;',
+    'justify-content:center !important;',
+    '}',
+    '.report-header h1, .report-header h2, .report-header h3, .report-header h4, .report-header h5, .report-header h6,',
+    '.payslip-header h1, .payslip-header h2, .payslip-header h3, .payslip-header h4, .payslip-header h5, .payslip-header h6,',
+    '.hdr h1, .hdr h2, .hdr h3, .hdr h4, .hdr h5, .hdr h6,',
+    '.header-lines, .report-title, .report-period, .company-line, .company-name, .proj-title, .mr-project-title{',
+    'font-size:150% !important;',
+    'line-height:1.2 !important;',
+    '}'
+  ].join('');
+  var styleTag = '<style id="printHeaderStyle">' + rule + '</style>';
+  if (/<\/head>/i.test(html)) {
+    return html.replace(/<\/head>/i, styleTag + '</head>');
+  }
+  return html + styleTag;
+}
 function printReport(html, options){
   var opts = options || {};
   var orientation = normalizePrintOrientation(opts.orientation);
-  var doc = injectPrintOrientation(html, orientation);
+  var doc = injectPrintHeaderStyle(injectPrintOrientation(html, orientation));
   var target = opts.targetWindow;
   var w = target || window.open('', opts.name || '_blank', opts.features || 'width=1024,height=768');
   if (!w) {
@@ -1101,6 +1132,7 @@ function printReport(html, options){
     if (!companyName) {
       companyName = (typeof COMPANY_OPTIONS !== 'undefined' && Array.isArray(COMPANY_OPTIONS) && COMPANY_OPTIONS[0]) ? COMPANY_OPTIONS[0] : 'PayrollPro';
     }
+    companyName = normalizePrintCompanyName(companyName);
     var additionalIncomeItems = Array.isArray(data.additionalIncomeDetails) ? data.additionalIncomeDetails : [];
     var additionalIncomeTotal = toNum(data.additionalIncomeTotal);
     if (!(additionalIncomeTotal > 0)) {
@@ -9586,7 +9618,7 @@ document.addEventListener('DOMContentLoaded', function(){
       '</head><body>' +
       '<div id="printWrap">' +
       '<div class="report-header">' +
-      '<div class="company-name">Edifice Group Corp.</div>' +
+      '<div class="company-name">Edifice Group Corp & Portafolio Interiors Inc.</div>' +
       voidedLabel +
       '<div class="report-title">PAYROLL \u2013 COMPRESSED WORK WEEK</div>' +
       (startDate && endDate ? '<div class="report-period">Payroll Period: ' + startDate + ' to ' + endDate + '</div>' : '') +
@@ -9601,9 +9633,9 @@ document.addEventListener('DOMContentLoaded', function(){
 
 function getDeductionsReportCompanyName() {
   if (typeof COMPANY_OPTIONS !== 'undefined' && Array.isArray(COMPANY_OPTIONS) && COMPANY_OPTIONS[0]) {
-    return COMPANY_OPTIONS[0];
+    return normalizePrintCompanyName(COMPANY_OPTIONS[0]);
   }
-  return 'PayrollPro';
+  return normalizePrintCompanyName('PayrollPro');
 }
 
 function buildDeductionsReportData() {
@@ -9727,9 +9759,9 @@ document.addEventListener('DOMContentLoaded', function(){
 
 function getOvertimeReportCompanyName() {
   if (typeof COMPANY_OPTIONS !== 'undefined' && Array.isArray(COMPANY_OPTIONS) && COMPANY_OPTIONS[0]) {
-    return COMPANY_OPTIONS[0];
+    return normalizePrintCompanyName(COMPANY_OPTIONS[0]);
   }
-  return 'PayrollPro';
+  return normalizePrintCompanyName('PayrollPro');
 }
 
 function buildOvertimeReportData() {
@@ -18784,9 +18816,9 @@ document.addEventListener('DOMContentLoaded', function(){
   }
   function getDtrReportCompanyName(){
     if (typeof COMPANY_OPTIONS !== 'undefined' && Array.isArray(COMPANY_OPTIONS) && COMPANY_OPTIONS[0]) {
-      return COMPANY_OPTIONS[0];
+      return normalizePrintCompanyName(COMPANY_OPTIONS[0]);
     }
-    return 'PayrollPro';
+    return normalizePrintCompanyName('PayrollPro');
   }
   function getDtrPeriodText(){
     var start = (document.getElementById('weekStart') || {}).value || '';


### PR DESCRIPTION
### Motivation
- Ensure printed reports show the exact requested company label and to map common internal names to a single canonical print name for consistency across all report outputs.

### Description
- Added `normalizePrintCompanyName(name)` which returns the canonical `Edifice Group Corp & Portafolio Interiors Inc.` and maps common inputs such as `PayrollPro`, `Edifice`, `Portafolio`, and `Edifice & Portafolio` to that canonical label.
- Replaced the hardcoded print header value with the canonical full name in the payroll print HTML so the literal print header matches the normalization behavior.
- Updated functions that supply company names for prints (e.g. where defaults were `COMPANY_OPTIONS[0]` or `'PayrollPro'`) to call `normalizePrintCompanyName(...)` so all report types use the same normalized label.
- Added `injectPrintHeaderStyle(html)` and applied it inside `printReport` to ensure header styling is included consistently in printed output.

### Testing
- Ran `rg` searches for `normalizePrintCompanyName` and company-name occurrences to confirm replacements were applied, and the search returned the updated canonical name (succeeded).
- Executed the replacement script used to patch `index.html` (the `python` script invoked) and confirmed it completed without error (succeeded).
- Inspected the resulting changes with `git diff` and `nl` to verify the exact locations and content of modifications (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e7e091e1c8328a3788ccb84ac79b5)