### PR TITLE
Preserve employee contribution checkbox edits and protect computed payroll hours from cloud overwrite

### DIFF
--- a/index.html
+++ b/index.html
@@ -947,6 +947,18 @@ function __kvHasMeaningfulPeriodMap(obj){
   } catch(_) {}
   return false;
 }
+function __kvHasMeaningfulHoursMap(obj){
+  try {
+    if (!obj || typeof obj !== 'object') return false;
+    return Object.keys(obj).some((empId) => {
+      const v = Number(obj[empId]);
+      return Number.isFinite(v) && Math.abs(v) > 0.0001;
+    });
+  } catch (_) {}
+  return false;
+}
+try { window.__kvHasMeaningfulHoursMap = __kvHasMeaningfulHoursMap; } catch (_) {}
+const __KV_COMPUTED_LOCAL_KEYS = new Set(['payroll_reg_hours', 'payroll_ot_hours']);
 const __kvBootCloudFirstPeriodKeys = new Set([
   'payroll_other_deductions_details',
   'payroll_other_deductions_total',
@@ -1023,15 +1035,45 @@ function __kvSetupRealtimeChannel(force = false) {
         const eventType = payload && payload.eventType;
         const key = (payload && payload.new && payload.new.key) || (payload && payload.old && payload.old.key);
         if (!key || !KNOWN_KEYS.includes(key)) return;
+        if (__KV_COMPUTED_LOCAL_KEYS.has(key)) {
+          // Regular/OT hours are derived from records on each device; do not ingest cloud realtime events.
+          return;
+        }
         if (eventType === 'INSERT' || eventType === 'UPDATE') {
           const serialized = safeStringify(payload && payload.new ? payload.new.value : undefined);
           const nextValue = serialized == null ? 'null' : String(serialized);
           const current = localStorage.getItem(key);
+          // Guard against stale/empty cloud updates wiping computed payroll hours.
+          if (key === 'payroll_reg_hours' || key === 'payroll_ot_hours') {
+            try {
+              const incomingObj = JSON.parse(nextValue || 'null');
+              const currentObj = current ? JSON.parse(current) : null;
+              const incomingHas = __kvHasMeaningfulHoursMap(incomingObj);
+              const currentHas = __kvHasMeaningfulHoursMap(currentObj);
+              if (!incomingHas && currentHas) return;
+            } catch (_) {}
+          }
           if (nextValue !== current) {
             try { __origSetItem(key, nextValue); } catch {}
             queueHydrateRerender();
           }
         } else if (eventType === 'DELETE') {
+          // Guard against remote deletes wiping computed payroll hour maps.
+          if (key === 'payroll_reg_hours' || key === 'payroll_ot_hours') {
+            try {
+              const currentRaw = localStorage.getItem(key);
+              const currentObj = currentRaw ? JSON.parse(currentRaw) : null;
+              if (__kvHasMeaningfulHoursMap(currentObj)) {
+                // Keep local computed values and heal cloud row asynchronously.
+                try {
+                  if (window.__kvSyncEnabled && window.__kvSyncEnabled() && typeof window.writeKV === 'function') {
+                    window.writeKV(key, currentObj);
+                  }
+                } catch (_) {}
+                return;
+              }
+            } catch (_) {}
+          }
           if (localStorage.getItem(key) !== null) {
             try { __origRemoveItem(key); } catch {}
             queueHydrateRerender();
@@ -1202,7 +1244,7 @@ try { window.__kvEnableSync = __kvEnableSync; window.__kvDisableSync = __kvDisab
 
 let __kvBypassNextSetItem = false;
 const __CLOUD_ONLY_KEYS = new Set(['payroll_loan_tracker','payroll_loan_sss','payroll_loan_pagibig','payroll_vale','payroll_vale_wed','payroll_other_deductions_details','payroll_other_deductions_total','payroll_additional_income_details','payroll_additional_income_total']);
-function __kvShouldMirror(k){ return KNOWN_KEYS.includes(k) && !__CLOUD_ONLY_KEYS.has(k); }
+function __kvShouldMirror(k){ return KNOWN_KEYS.includes(k) && !__CLOUD_ONLY_KEYS.has(k) && !__KV_COMPUTED_LOCAL_KEYS.has(k); }
 
 const store = (() => {
   const pendingTimers = new Map();
@@ -1296,6 +1338,9 @@ async function __kvHydrateOnce(){
 
     for (const row of (data || [])) {
       const k = row.key;
+      if (__KV_COMPUTED_LOCAL_KEYS.has(k)) {
+        continue;
+      }
       const cloudStr = safeStringify(row.value);
       const cur = localStorage.getItem(k);
 
@@ -1321,6 +1366,15 @@ async function __kvHydrateOnce(){
         if (typeof decision === 'boolean') preferLocal = decision;
       } catch(_) {}
 
+      // Contribution flags can be edited and refreshed quickly; prefer the newer side.
+      if (k === 'payroll_contrib_flags') {
+        const localTs = Number(localObj && localObj.__meta && localObj.__meta.lastUpdatedAt) || 0;
+        const cloudTs = Number(cloudObj && cloudObj.__meta && cloudObj.__meta.lastUpdatedAt) || 0;
+        const localHasAny = !!(localObj && typeof localObj === 'object' && Object.keys(localObj).some(x => x !== '__meta'));
+        const cloudHasAny = !!(cloudObj && typeof cloudObj === 'object' && Object.keys(cloudObj).some(x => x !== '__meta'));
+        if ((localTs && localTs >= cloudTs) || (localHasAny && !cloudHasAny)) preferLocal = true;
+      }
+
       // Payroll history is append-heavy and does not carry __meta timestamps.
       // Prefer the side with the newer snapshot timeline so a newly finalized run
       // is not lost after refresh when cloud replication is delayed.
@@ -1328,6 +1382,14 @@ async function __kvHydrateOnce(){
         const localTs = __kvPayrollHistoryLatestTs(localObj);
         const cloudTs = __kvPayrollHistoryLatestTs(cloudObj);
         if (localTs > cloudTs) preferLocal = true;
+      }
+
+      // Protect computed payroll hours from being overwritten by an empty cloud payload
+      // during startup/reconnect races.
+      if (k === 'payroll_reg_hours' || k === 'payroll_ot_hours') {
+        const localHas = __kvHasMeaningfulHoursMap(localObj);
+        const cloudHas = __kvHasMeaningfulHoursMap(cloudObj);
+        if (localHas && !cloudHas) preferLocal = true;
       }
 
       if (preferLocal) {
@@ -5144,6 +5206,8 @@ function persistEmployeeContribFlag(empId, key, checked){
   const latest = readContribFlagsFromStorage();
   if (!latest[empId] || typeof latest[empId] !== 'object') latest[empId] = {};
   latest[empId][key] = !!checked;
+  latest.__meta = latest.__meta && typeof latest.__meta === 'object' ? latest.__meta : {};
+  latest.__meta.lastUpdatedAt = Date.now();
   contribFlags = latest;
   localStorage.setItem(LS_CONTRIB_FLAGS, JSON.stringify(latest));
 
@@ -17640,6 +17704,8 @@ document.getElementById('addEmployeeBtn').addEventListener('click', ()=>{
   // Initialize default contribution deduction flags for new employee if not already set
   if (!contribFlags[id]) {
     contribFlags[id] = { pagibig: true, philhealth: true, sss: true };
+    contribFlags.__meta = contribFlags.__meta && typeof contribFlags.__meta === 'object' ? contribFlags.__meta : {};
+    contribFlags.__meta.lastUpdatedAt = Date.now();
     localStorage.setItem(LS_CONTRIB_FLAGS, JSON.stringify(contribFlags));
   }
   storedEmployees[id].contribFlags = {
@@ -19113,20 +19179,30 @@ function calculatePayrollFromRecords(){
       } catch (err) {}
       // Re-render the DTR results table with updated filters
       if (typeof renderResults === 'function') renderResults();
-      // Aggregate hours from the rendered DTR table
+      // Aggregate hours from the rendered DTR table.
+      // If no rows are available yet (transient render/filter state),
+      // fall back to direct record computation so OT pay does not reset to zero.
       const rows = document.querySelectorAll('#resultsTable tbody tr');
       const regTotals = {};
       const otTotals = {};
-      rows.forEach(row => {
-        const cells = row.cells;
-        if (!cells || cells.length < 13) return;
-        const empId = cells[0].textContent.trim();
-        // Column 11: total regular hours; column 12: OT hours
-        const regVal = parseFloat(cells[11].textContent) || 0;
-        const otVal  = parseFloat(cells[12].textContent) || 0;
-        regTotals[empId] = (regTotals[empId] || 0) + regVal;
-        otTotals[empId]  = (otTotals[empId]  || 0) + otVal;
-      });
+      if (rows.length > 0) {
+        rows.forEach(row => {
+          const cells = row.cells;
+          if (!cells || cells.length < 13) return;
+          const empId = cells[0].textContent.trim();
+          // Column 11: total regular hours; column 12: OT hours
+          const regVal = parseFloat(cells[11].textContent) || 0;
+          const otVal  = parseFloat(cells[12].textContent) || 0;
+          regTotals[empId] = (regTotals[empId] || 0) + regVal;
+          otTotals[empId]  = (otTotals[empId]  || 0) + otVal;
+        });
+      } else {
+        const directStart = (weekStartEl && weekStartEl.value) ? weekStartEl.value : '';
+        const directEnd = (weekEndEl && weekEndEl.value) ? weekEndEl.value : '';
+        const directTotals = computeHoursForDateRange(directStart, directEnd);
+        Object.assign(regTotals, (directTotals && directTotals.totalsReg) || {});
+        Object.assign(otTotals, (directTotals && directTotals.totalsOT) || {});
+      }
       // Restore original filters and search
       if (searchInput) searchInput.value = origSearch;
       if (filterSelect) {
@@ -19154,15 +19230,41 @@ function calculatePayrollFromRecords(){
       try {
         if (typeof window.applyDtrDateFilter === 'function') applyDtrDateFilter();
       } catch (_) {}
-      // Apply aggregated hours to regHours and otHours, rounding to two decimals
-      regHours = {};
-      otHours = {};
-      Object.keys(regTotals).forEach(id => {
-        regHours[id] = +(regTotals[id]).toFixed(2);
-      });
-      Object.keys(otTotals).forEach(id => {
-        otHours[id] = +(otTotals[id]).toFixed(2);
-      });
+      // Apply aggregated hours to regHours and otHours, rounding to two decimals.
+      // If the aggregation is empty while prior computed hours exist, keep the current
+      // values to avoid transient UI/network races wiping OT pay.
+      const regHasTotals = Object.keys(regTotals).length > 0;
+      const otHasTotals = Object.keys(otTotals).length > 0;
+      const hasAggregatedTotals = regHasTotals || otHasTotals;
+      const hasMeaningfulHoursMap = (obj) => {
+        try {
+          if (typeof __kvHasMeaningfulHoursMap === 'function') return __kvHasMeaningfulHoursMap(obj);
+        } catch (_) {}
+        try {
+          if (typeof window !== 'undefined' && typeof window.__kvHasMeaningfulHoursMap === 'function') {
+            return window.__kvHasMeaningfulHoursMap(obj);
+          }
+        } catch (_) {}
+        try {
+          if (!obj || typeof obj !== 'object') return false;
+          return Object.keys(obj).some((empId) => {
+            const v = Number(obj[empId]);
+            return Number.isFinite(v) && Math.abs(v) > 0.0001;
+          });
+        } catch (_) {}
+        return false;
+      };
+      const existingHasHours = hasMeaningfulHoursMap(regHours) || hasMeaningfulHoursMap(otHours);
+      if (hasAggregatedTotals || !existingHasHours) {
+        regHours = {};
+        otHours = {};
+        Object.keys(regTotals).forEach(id => {
+          regHours[id] = +(regTotals[id]).toFixed(2);
+        });
+        Object.keys(otTotals).forEach(id => {
+          otHours[id] = +(otTotals[id]).toFixed(2);
+        });
+      }
 
       // Compute Night Diff using the same payroll period boundaries.
       // This keeps ND in sync even when this Results-table path is used.


### PR DESCRIPTION
### Motivation
- Checkbox changes on the Employees tab could appear to save locally but be reverted after a refresh because cloud hydration overwrote local `payroll_contrib_flags` with an older cloud snapshot. 
- Computed per-employee hours (`payroll_reg_hours` / `payroll_ot_hours`) could be zeroed by empty/stale cloud realtime or hydrate events, causing transient UI/payroll resets.

### Description
- Add metadata and conflict logic for contribution flags by writing `__meta.lastUpdatedAt` in `persistEmployeeContribFlag()` and when initializing defaults for a new employee so hydration can decide which side is newer. 
- Update boot hydration (`__kvHydrateOnce`) to prefer newer local `payroll_contrib_flags` (or local non-empty when cloud is empty) and to skip importing computed-local keys `payroll_reg_hours`/`payroll_ot_hours` so local computed values are preserved. 
- Add `__KV_COMPUTED_LOCAL_KEYS` and `__kvHasMeaningfulHoursMap()` and use them to: exclude computed keys from mirror decisions (`__kvShouldMirror`), skip realtime ingestion for those keys, ignore remote empty/DELETE events that would wipe local computed hours, and attempt an asynchronous heal-upsert when a remote delete would otherwise remove meaningful local computed hours. 
- Harden `calculatePayrollFromRecords()` so it falls back to `computeHoursForDateRange()` when the Results table has no rows and avoids overwriting existing `regHours`/`otHours` when aggregation is empty to prevent transient resets.

### Testing
- Ran targeted code searches with `rg` to confirm new helpers/keys and that `__KV_COMPUTED_LOCAL_KEYS` is referenced from realtime, hydrate-skip, and mirror-decision logic. 
- Ran `git diff --check` which reported no formatting or trailing-whitespace issues. 
- Inspected repository state with `git status --short` and committed the change successfully with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69984658a9708328917bc3e4914ad8c1)