### PR TITLE
Introduce payrollDomain module and wire into UI to centralize payroll calculations

### DIFF
--- a/index.html
+++ b/index.html
@@ -3759,6 +3759,15 @@ function getOvertimePayForEmployee(empId, rateOverride) {
 
 function getNightDifferentialPayForEmployee(empId) {
   const value = Number((nightDiffByEmployee && nightDiffByEmployee[empId]) || 0);
+  const domain = (typeof window !== 'undefined' && window.payrollDomain) ? window.payrollDomain : null;
+  if (domain && typeof domain.resolveNightDifferentialPay === 'function') {
+    return domain.resolveNightDifferentialPay({
+      hourlyRate: Number(getEmployeeHourlyRate(empId)) || 0,
+      precomputedNightDiffPay: value,
+      settings: (typeof getNightDifferentialSettings === 'function') ? getNightDifferentialSettings() : null,
+      preferPrecomputed: true,
+    }).pay;
+  }
   if (!Number.isFinite(value)) return 0;
   if (typeof roundToCents === 'function') return roundToCents(value);
   return Math.round(value * 100) / 100;
@@ -5273,6 +5282,7 @@ function applyLoanTrackerToPeriod(pk, options){
   const updateMaps = opts.updateMaps === true;
   const commitCashAdvance = opts.commitCashAdvance === true;
   const canWriteMaps = createEntries || force || updateMaps;
+  const domain = (typeof window !== 'undefined' && window.payrollDomain) ? window.payrollDomain : null;
   ensureLoanTrackerShape(loanTracker);
   if (!pk) return;
   const div = Number(divisor) || 1;
@@ -5296,7 +5306,6 @@ function applyLoanTrackerToPeriod(pk, options){
 
     const principal = roundToCents(entry.principal || 0);
     const weekly = roundToCents(entry.weekly || 0);
-    const shouldRun = (entry.active === true) && (principal > 0) && (weekly > 0);
     const allowCommit = commitCashAdvance === true;
     const existingApplied = getLoanTrackerApplied(pk, empId, type);
     const existingPayment = allowCommit ? getLoanTrackerPayment(pk, empId, type) : null;
@@ -5306,17 +5315,30 @@ function applyLoanTrackerToPeriod(pk, options){
       clearLoanTrackerApplied(pk, empId, type);
     };
 
+    const paidBefore = sumLoanTrackerAppliedBefore(pk, empId, type);
+    const baseline = loanTrackerPaidBaseline(entry, type);
+    const decision = (domain && typeof domain.calculatePrincipalLoanDeductionDecision === 'function')
+      ? domain.calculatePrincipalLoanDeductionDecision({
+        active: entry.active,
+        principal,
+        periodicAmount: weekly,
+        paidBefore,
+        baseline,
+        existingApplied,
+      })
+      : null;
+
+    const shouldRun = decision ? decision.shouldRun : ((entry.active === true) && (principal > 0) && (weekly > 0));
+
     if (!shouldRun) {
       if (existingApplied != null) return roundToCents(existingApplied || 0);
       if (existingPayment) return roundToCents(Number(existingPayment.amount) || 0);
+      if (decision && decision.shouldDeactivate && entry.active) { entry.active = false; changed = true; }
       clearForThisPeriod();
       return 0;
     }
 
-    const paidBefore = sumLoanTrackerAppliedBefore(pk, empId, type);
-    const baseline = loanTrackerPaidBaseline(entry, type);
-    const effectivePaidBefore = Math.max(0, roundToCents(paidBefore - baseline));
-    const remainingBefore = roundToCents(principal - effectivePaidBefore);
+    const remainingBefore = decision ? decision.remainingBefore : roundToCents(principal - Math.max(0, roundToCents(paidBefore - baseline)));
     if (remainingBefore <= 0) {
       if (entry.active) { entry.active = false; changed = true; }
       clearForThisPeriod();
@@ -5324,7 +5346,7 @@ function applyLoanTrackerToPeriod(pk, options){
     }
 
     let scheduled = existingApplied;
-    const desired = roundToCents(Math.min(weekly, remainingBefore));
+    const desired = decision ? decision.desired : roundToCents(Math.min(weekly, remainingBefore));
 
     if (allowCommit && existingPayment && scheduled == null) {
       const paidAmount = roundToCents(Number(existingPayment.amount) || 0);
@@ -5366,7 +5388,20 @@ function applyLoanTrackerToPeriod(pk, options){
     const principal = roundToCents(entry.principal || 0);
     const monthly = roundToCents(entry.monthly || 0);
     const basePerPeriod = (div > 0) ? roundToCents(monthly / div) : roundToCents(monthly);
-    const shouldRun = (entry.active === true) && (principal > 0) && (monthly > 0) && (basePerPeriod > 0);
+    const paidBefore = sumLoanTrackerAppliedBefore(pk, empId, type);
+    const baseline = loanTrackerPaidBaseline(entry, type);
+    const existingApplied = getLoanTrackerApplied(pk, empId, type);
+    const decision = (domain && typeof domain.calculatePrincipalLoanDeductionDecision === 'function')
+      ? domain.calculatePrincipalLoanDeductionDecision({
+        active: entry.active,
+        principal,
+        periodicAmount: basePerPeriod,
+        paidBefore,
+        baseline,
+        existingApplied,
+      })
+      : null;
+    const shouldRun = decision ? decision.shouldRun : ((entry.active === true) && (principal > 0) && (monthly > 0) && (basePerPeriod > 0));
 
     const clearForThisPeriod = () => {
       if (!(createEntries || force)) return;
@@ -5378,23 +5413,20 @@ function applyLoanTrackerToPeriod(pk, options){
       return 0;
     }
 
-    const paidBefore = sumLoanTrackerAppliedBefore(pk, empId, type);
-    const baseline = loanTrackerPaidBaseline(entry, type);
-    const effectivePaidBefore = Math.max(0, roundToCents(paidBefore - baseline));
-    const remainingBefore = roundToCents(principal - effectivePaidBefore);
+    const remainingBefore = decision ? decision.remainingBefore : roundToCents(principal - Math.max(0, roundToCents(paidBefore - baseline)));
     if (remainingBefore <= 0) {
       if (entry.active) { entry.active = false; changed = true; }
       clearForThisPeriod();
       return 0;
     }
 
-    const desired = roundToCents(Math.min(basePerPeriod, remainingBefore));
+    const desired = decision ? decision.desired : roundToCents(Math.min(basePerPeriod, remainingBefore));
     if (desired <= 0) {
       clearForThisPeriod();
       return 0;
     }
 
-    let scheduled = getLoanTrackerApplied(pk, empId, type);
+    let scheduled = existingApplied;
 
     if (scheduled == null || force){
       if (!createEntries && scheduled == null && !force) {
@@ -5435,7 +5467,9 @@ function applyLoanTrackerToPeriod(pk, options){
     let piMonthly = 0;
     for (const type of LOAN_TYPES_PI){
       const entry = getLoanTrackerEntry(empId, type);
-      const monthly = roundToCents(entry && entry.active ? (entry.monthly || 0) : 0);
+      const monthly = (domain && typeof domain.calculatePagibigLoanPerPeriod === 'function')
+        ? roundToCents(domain.calculatePagibigLoanPerPeriod({ active: entry && entry.active, monthly: entry && entry.monthly, divisor: 1 }))
+        : roundToCents(entry && entry.active ? (entry.monthly || 0) : 0);
       if (monthly > 0) piMonthly += monthly;
     }
     if (canWriteMaps) setMapValue(loanPI, empId, roundToCents(piMonthly));
@@ -6093,6 +6127,10 @@ function normalizeAdditionalIncomeItems(items){
 }
 
 function computeAdditionalIncomeTotal(items){
+  const domain = (typeof window !== 'undefined' && window.payrollDomain) ? window.payrollDomain : null;
+  if (domain && typeof domain.totalAdditionalIncome === 'function') {
+    return roundToCents(domain.totalAdditionalIncome(items || []));
+  }
   if (!Array.isArray(items)) return 0;
   const total = items.reduce((sum, item) => sum + sanitizeAdditionalIncomeAmount(item && item.amount), 0);
   return roundToCents(total);
@@ -6211,6 +6249,10 @@ function normalizeOtherDeductionItems(items){
 }
 
 function computeOtherDeductionsTotal(items){
+  const domain = (typeof window !== 'undefined' && window.payrollDomain) ? window.payrollDomain : null;
+  if (domain && typeof domain.totalOtherDeductions === 'function') {
+    return roundToCents(domain.totalOtherDeductions(items || []));
+  }
   if (!Array.isArray(items)) return 0;
   const total = items.reduce((sum, item) => sum + sanitizeOtherDeductionAmount(item && item.amount), 0);
   return roundToCents(total);
@@ -6912,31 +6954,37 @@ function renderDeductionsTable(){
     const v = roundToCents(vale[emp.id] ?? 0);
     const vW = roundToCents(valeWed[emp.id] ?? 0);
     const otherDeductionsAmount = roundToCents(getOtherDeductionsTotal(emp.id));
-    const regPay = +(rH * rate).toFixed(2);
-    // Use dynamic contribution tables for Pag-IBIG and PhilHealth.  Determine the
-    // applicable rate based on monthly income and multiply by regular pay.
-    const monthly = rate * 8 * 24;
-    const piRate = pagibigRateByMonthly(monthly);
-    const phRate = philhealthRateByMonthly(monthly);
-    const flags = (typeof contribFlags !== 'undefined' && contribFlags[emp.id]) || {};
-    const div = Number(divisor) || 1;
-    const pagibig = (flags.pagibig === false) ? 0 : +((regPay * piRate).toFixed(2));
-    const philhealth = (flags.philhealth === false) ? 0 : +((regPay * phRate).toFixed(2));
-    const sssFull = (flags.sss === false) ? 0 : sssShareByMonthly(monthly);
-    const sss = (flags.sss === false) ? 0 : +((sssFull / div).toFixed(2));
-    const sssLoan = +(lSSS / div).toFixed(2);
-    const piLoan = +(lPI / div).toFixed(2);
-    const rowRaw = {
-      pagibig,
-      philhealth,
-      sss,
-      loanSSS: sssLoan,
-      loanPI: piLoan,
+    const domainComputed = computePayrollDomainRow(emp.id, {
+      regularHours: rH,
+      hourlyRate: rate,
+      loanSSS: lSSS,
+      loanPI: lPI,
+      vale: v,
+      valeWed: vW,
+      otherDeductionsTotal: otherDeductionsAmount,
+      applyLoansWithoutWorkedTime: true
+    });
+    const rowRaw = domainComputed.row ? {
+      pagibig: domainComputed.row.pagibig_deduction,
+      philhealth: domainComputed.row.philhealth_deduction,
+      sss: domainComputed.row.sss_deduction,
+      loanSSS: domainComputed.row.loan_sss_deduction,
+      loanPI: domainComputed.row.loan_pagibig_deduction,
+      vale: domainComputed.row.vale_deduction,
+      adjustments: domainComputed.row.other_deductions,
+      valeWed: domainComputed.row.vale_wed_deduction,
+      total: domainComputed.row.total_deductions
+    } : {
+      pagibig: 0,
+      philhealth: 0,
+      sss: 0,
+      loanSSS: 0,
+      loanPI: 0,
       vale: v,
       adjustments: otherDeductionsAmount,
-      valeWed: vW
+      valeWed: vW,
+      total: roundToCents(v + vW + otherDeductionsAmount)
     };
-    rowRaw.total = roundToCents(pagibig + philhealth + sss + sssLoan + piLoan + v + vW + otherDeductionsAmount);
     const rowEffective = computeEffectiveDeductionValues(rowRaw);
   const editableRawValues = {
     loanSSS: lSSS,
@@ -7235,29 +7283,37 @@ function updateDeductionRowDisplay(empId){
   const v = roundToCents(vale?.[empKey] ?? 0);
   const vW = roundToCents(valeWed?.[empKey] ?? 0);
   const otherDeductionsAmount = roundToCents(getOtherDeductionsTotal(empKey));
-  const regPay = +(rH * rate).toFixed(2);
-  const monthly = rate * 8 * 24;
-  const piRate = pagibigRateByMonthly(monthly);
-  const phRate = philhealthRateByMonthly(monthly);
-  const flags = (typeof contribFlags !== 'undefined' && contribFlags && contribFlags[empKey]) || {};
-  const div = Number(divisor) || 1;
-  const pagibig = (flags.pagibig === false) ? 0 : +((regPay * piRate).toFixed(2));
-  const philhealth = (flags.philhealth === false) ? 0 : +((regPay * phRate).toFixed(2));
-  const sssFull = (flags.sss === false) ? 0 : sssShareByMonthly(monthly);
-  const sss = (flags.sss === false) ? 0 : +((sssFull / div).toFixed(2));
-  const sssLoan = hasWorkedTime ? +(lSSS / div).toFixed(2) : 0;
-  const piLoan = hasWorkedTime ? +(lPI / div).toFixed(2) : 0;
-  const rowRaw = {
-    pagibig,
-    philhealth,
-    sss,
-    loanSSS: sssLoan,
-    loanPI: piLoan,
+  const domainComputed = computePayrollDomainRow(empKey, {
+    regularHours: rH,
+    hourlyRate: rate,
+    loanSSS: lSSS,
+    loanPI: lPI,
+    vale: v,
+    valeWed: vW,
+    otherDeductionsTotal: otherDeductionsAmount,
+    applyLoansWithoutWorkedTime: false
+  });
+  const rowRaw = domainComputed.row ? {
+    pagibig: domainComputed.row.pagibig_deduction,
+    philhealth: domainComputed.row.philhealth_deduction,
+    sss: domainComputed.row.sss_deduction,
+    loanSSS: domainComputed.row.loan_sss_deduction,
+    loanPI: domainComputed.row.loan_pagibig_deduction,
+    vale: domainComputed.row.vale_deduction,
+    adjustments: domainComputed.row.other_deductions,
+    valeWed: domainComputed.row.vale_wed_deduction,
+    total: domainComputed.row.total_deductions
+  } : {
+    pagibig: 0,
+    philhealth: 0,
+    sss: 0,
+    loanSSS: hasWorkedTime ? lSSS : 0,
+    loanPI: hasWorkedTime ? lPI : 0,
     vale: v,
     adjustments: otherDeductionsAmount,
-    valeWed: vW
+    valeWed: vW,
+    total: roundToCents(v + vW + otherDeductionsAmount)
   };
-  rowRaw.total = roundToCents(pagibig + philhealth + sss + sssLoan + piLoan + v + vW + otherDeductionsAmount);
   const rowEffective = computeEffectiveDeductionValues(rowRaw);
   const editableRawValues = {
     loanSSS: lSSS,
@@ -7463,11 +7519,11 @@ function updateOvertimeGrandTotals() {
   if (!tbody) return;
   const totalRow = tbody.querySelector('tr.grand-total-row');
   if (!totalRow) return;
+  const domain = (typeof window !== 'undefined' && window.payrollDomain) ? window.payrollDomain : null;
   let totalOtHours = 0;
   let totalAdjHours = 0;
   let totalFinalHours = 0;
-  let totalNightDiff = 0;
-  let totalOtPay = 0;
+  const overtimeRows = [];
   getEmployeeList().forEach(emp => {
     const baseRate = getEmployeeHourlyRate(emp.id);
     const otTotal = getOvertimeHoursTotal(emp.id);
@@ -7478,9 +7534,15 @@ function updateOvertimeGrandTotals() {
     totalOtHours = roundToCents(totalOtHours + otTotal);
     totalAdjHours = roundToCents(totalAdjHours + adj);
     totalFinalHours = roundToCents(totalFinalHours + otFinal);
-    totalNightDiff = roundToCents(totalNightDiff + nightDiffPay);
-    totalOtPay = roundToCents(totalOtPay + otPay);
+    overtimeRows.push({ overtime_hours: otFinal, night_diff_pay: nightDiffPay, overtime_pay: otPay });
   });
+  const reduced = (domain && typeof domain.reduceOvertimeTotals === 'function')
+    ? domain.reduceOvertimeTotals(overtimeRows)
+    : overtimeRows.reduce((acc, row) => ({
+      overtime_hours: roundToCents((acc.overtime_hours || 0) + Number(row.overtime_hours || 0)),
+      night_diff_pay: roundToCents((acc.night_diff_pay || 0) + Number(row.night_diff_pay || 0)),
+      overtime_pay: roundToCents((acc.overtime_pay || 0) + Number(row.overtime_pay || 0)),
+    }), { overtime_hours: 0, night_diff_pay: 0, overtime_pay: 0 });
   const formatZeroDisplay = (value) => {
     const num = Number(value);
     if (!Number.isFinite(num) || Math.abs(num) < 0.005) return '-';
@@ -7493,8 +7555,8 @@ function updateOvertimeGrandTotals() {
   setCell('totalOtHours', totalOtHours);
   setCell('adjOtHours', totalAdjHours);
   setCell('finalOtHours', totalFinalHours);
-  setCell('nightDiff', totalNightDiff);
-  setCell('otPay', totalOtPay);
+  setCell('nightDiff', reduced.night_diff_pay || 0);
+  setCell('otPay', reduced.overtime_pay || 0);
 }
 
 function updateOvertimeRowForEmployee(empId){
@@ -8031,6 +8093,58 @@ function philhealthRateByMonthly(monthly){
   return Number(rows[rows.length-1].rate)||0;
 }
 
+function computePayrollDomainRow(empId, overrides = {}) {
+  const domain = (typeof window !== 'undefined' && window.payrollDomain) ? window.payrollDomain : null;
+  const rate = Number(overrides.hourlyRate ?? getEmployeeHourlyRate(empId)) || 0;
+  const regularHours = Number(overrides.regularHours ?? regHours?.[empId] ?? 0) || 0;
+  const overtimeHours = Number(overrides.overtimeHours ?? getOvertimeHoursTotal(empId)) || 0;
+  const overtimeAdjustmentHours = Number(overrides.overtimeAdjustmentHours ?? getOvertimeAdjustmentHours(empId)) || 0;
+  const regularAdjustmentHours = Number(overrides.regularAdjustmentHours ?? getRegularAdjustmentHours(empId)) || 0;
+  const otherDeductionsAmount = Number(overrides.otherDeductionsTotal ?? roundToCents(getOtherDeductionsTotal(empId))) || 0;
+  const additionalIncomeTotal = Number(overrides.additionalIncomeTotal ?? getAdditionalIncomeTotal(empId)) || 0;
+  const bantayAmount = Number(overrides.bantayAmount ?? 0) || 0;
+  const flags = (typeof contribFlags !== 'undefined' && contribFlags && contribFlags[empId]) || {};
+  const div = Number(divisor) || 1;
+  const lSSS = roundToCents(Number(overrides.loanSSS ?? loanSSS?.[empId] ?? 0) || 0);
+  const lPI = roundToCents(Number(overrides.loanPI ?? loanPI?.[empId] ?? 0) || 0);
+  const v = roundToCents(Number(overrides.vale ?? vale?.[empId] ?? 0) || 0);
+  const vW = roundToCents(Number(overrides.valeWed ?? valeWed?.[empId] ?? 0) || 0);
+  const additionalIncomeShown = roundToCents(additionalIncomeTotal + bantayAmount);
+
+  const sssTable = (typeof getSssTable === 'function') ? getSssTable() : [];
+  const pagibigTable = (typeof getPagibigTable === 'function') ? getPagibigTable() : [];
+  const philhealthTable = (typeof getPhilhealthTable === 'function') ? getPhilhealthTable() : [];
+
+  if (domain && typeof domain.buildPayrollRow === 'function') {
+    const row = domain.buildPayrollRow({
+      employeeId: empId,
+      regularHours,
+      overtimeHours,
+      overtimeAdjustmentHours,
+      regularAdjustmentHours,
+      hourlyRate: rate,
+      overtimeMultiplier: (typeof getOvertimeMultiplier === 'function') ? getOvertimeMultiplier() : 1.25,
+      nightDiffPay: Number(overrides.nightDiffPay ?? getNightDifferentialPayForEmployee(empId)) || 0,
+      nightDifferentialSettings: (typeof getNightDifferentialSettings === 'function') ? getNightDifferentialSettings() : null,
+      additionalIncomeTotal: additionalIncomeShown,
+      otherDeductionsTotal: otherDeductionsAmount,
+      loanSSS: lSSS,
+      loanPI: lPI,
+      vale: v,
+      valeWed: vW,
+      divisor: div,
+      contributionFlags: flags,
+      sssTable,
+      pagibigTable,
+      philhealthTable,
+      applyLoansWithoutWorkedTime: !!overrides.applyLoansWithoutWorkedTime
+    });
+    return { row, rate, regularHours, additionalIncomeShown, otherDeductionsAmount, lSSS, lPI, v, vW };
+  }
+
+  return { row: null, rate, regularHours, additionalIncomeShown, otherDeductionsAmount, lSSS, lPI, v, vW };
+}
+
 function calculateRow(tr){  const readNum = sel => { const el = tr.querySelector(sel); if (!el) return 0; const v = (typeof el.value !== 'undefined' ? el.value : el.textContent); const n = parseFloat(String(v).replace(/,/g,'')); return isNaN(n)?0:n; };
   const w = (sel, val) => { const el = tr.querySelector(sel); if (!el) return; el.textContent = (val===0 ? '-' : (+val).toFixed(2)); };
 
@@ -8079,46 +8193,55 @@ function calculateRow(tr){  const readNum = sel => { const el = tr.querySelector
   const bVal = parseFloat((tr.querySelector('.bantay')?.value || '').trim()) || 0;
   const additionalIncomeShown = roundToCents(additionalIncome + bVal);
 
-  const regPay = roundToCents(reg * rate);
-  const adjPay = roundToCents(regAdjHours * rate);
-  const effectiveOtRate = getEffectiveOvertimeRateForEmployee(id, rate);
-  const baseOtPay = roundToCents(otTotal * effectiveOtRate);
-  const nightDiffPay = getNightDifferentialPayForEmployee(id);
-  const otPay = roundToCents(baseOtPay + nightDiffPay);
-  const gross = roundToCents(regPay + adjPay + additionalIncomeShown + otPay);
-  // Compute contributions using dynamic tables (employee share).  Determine the
-  // appropriate rate based on the monthly income and multiply by regular pay.
-  const monthly = rate * 8 * 24;
-  const piRate = pagibigRateByMonthly(monthly);
-  const phRate = philhealthRateByMonthly(monthly);
-  // Check per-employee contribution deduction flags; default to true if not set
-  const flags = contribFlags[id] || {};
-  const div = Number(divisor) || 1;
-  const hasWorkedTime = (reg > 0) || (otTotal > 0) || (regAdjHours > 0);
-  const hasCompensation = hasWorkedTime || (additionalIncomeShown > 0);
-  const pagibig = (hasCompensation && flags.pagibig !== false ? +((regPay * piRate)).toFixed(2) : 0);
-  const philhealth = (hasCompensation && flags.philhealth !== false ? +((regPay * phRate)).toFixed(2) : 0);
-  const sssFull = hasCompensation ? sssShareByMonthly(monthly) : 0;
-  const sss = (hasCompensation && flags.sss !== false ? +(sssFull / div).toFixed(2) : 0);
-  const sssLoan = hasWorkedTime ? +(lSSS / div).toFixed(2) : 0;
-  const piLoan = hasWorkedTime ? +(lPI / div).toFixed(2) : 0;
-  const valeAmt = v;
-  const wedValeAmt = vW;
+  const domainComputed = computePayrollDomainRow(id, {
+    regularHours: reg,
+    overtimeHours: otBase,
+    overtimeAdjustmentHours: adjOtHours,
+    regularAdjustmentHours: regAdjHours,
+    loanSSS: lSSS,
+    loanPI: lPI,
+    vale: v,
+    valeWed: vW,
+    otherDeductionsTotal: otherDeductionsAmount,
+    additionalIncomeTotal: additionalIncome,
+    bantayAmount: bVal,
+    applyLoansWithoutWorkedTime: false
+  });
 
-  const deductionRaw = {
-    pagibig,
-    philhealth,
-    sss,
-    loanSSS: sssLoan,
-    loanPI: piLoan,
-    vale: valeAmt,
+  const rowModel = domainComputed.row;
+  const regPay = rowModel ? rowModel.regular_pay : roundToCents(reg * rate);
+  const adjPay = rowModel ? rowModel.adjustment_pay : roundToCents(regAdjHours * rate);
+  const otPay = rowModel ? rowModel.overtime_pay : roundToCents((otTotal * getEffectiveOvertimeRateForEmployee(id, rate)) + getNightDifferentialPayForEmployee(id));
+  const gross = rowModel ? rowModel.gross_pay : roundToCents(regPay + adjPay + additionalIncomeShown + otPay);
+
+  const deductionRaw = rowModel ? {
+    pagibig: rowModel.pagibig_deduction,
+    philhealth: rowModel.philhealth_deduction,
+    sss: rowModel.sss_deduction,
+    loanSSS: rowModel.loan_sss_deduction,
+    loanPI: rowModel.loan_pagibig_deduction,
+    vale: rowModel.vale_deduction,
+    adjustments: rowModel.other_deductions,
+    valeWed: rowModel.vale_wed_deduction,
+    total: rowModel.total_deductions
+  } : {
+    pagibig: 0,
+    philhealth: 0,
+    sss: 0,
+    loanSSS: 0,
+    loanPI: 0,
+    vale: v,
     adjustments: otherDeductionsAmount,
-    valeWed: wedValeAmt
+    valeWed: vW,
+    total: 0
   };
-  deductionRaw.total = roundToCents(pagibig + philhealth + sss + sssLoan + piLoan + valeAmt + wedValeAmt + otherDeductionsAmount);
+
+  if (!rowModel) {
+    deductionRaw.total = roundToCents(deductionRaw.pagibig + deductionRaw.philhealth + deductionRaw.sss + deductionRaw.loanSSS + deductionRaw.loanPI + deductionRaw.vale + deductionRaw.valeWed + deductionRaw.adjustments);
+  }
   const deductionEffective = computeEffectiveDeductionValues(deductionRaw);
   const total = deductionEffective.total;
-  const net = roundToCents(gross - total);
+  const net = rowModel ? roundToCents(rowModel.gross_pay - total) : roundToCents(gross - total);
 
   w('.regPay', regPay);
   w('.otPay', otPay);
@@ -18849,9 +18972,18 @@ function computeHoursForDateRange(startDate, endDate) {
     }
     const ndMins = overlapMinsWithNightWindow(dayOtStartMins, dayOtEndMins);
     const hourlyRate = Number(getEmployeeHourlyRate(empId)) || 0;
-    const ndPay = (ndMins > 0 && hourlyRate > 0 && ndPremiumFactor > 0)
-      ? roundToCents(minsToDec(ndMins) * hourlyRate * ndPremiumFactor)
-      : 0;
+    const ndDomain = (typeof window !== 'undefined' && window.payrollDomain) ? window.payrollDomain : null;
+    const ndPay = (ndDomain && typeof ndDomain.resolveNightDifferentialPay === 'function')
+      ? ndDomain.resolveNightDifferentialPay({
+        hourlyRate,
+        nightDiffMinutes: ndMins,
+        precomputedNightDiffPay: null,
+        settings: ndSettings,
+        preferPrecomputed: false,
+      }).pay
+      : ((ndMins > 0 && hourlyRate > 0 && ndPremiumFactor > 0)
+        ? roundToCents(minsToDec(ndMins) * hourlyRate * ndPremiumFactor)
+        : 0);
     totalsND[empId] = roundToCents((totalsND[empId] || 0) + ndPay);
   }
   return { totalsReg, totalsOT, totalsND };
@@ -20372,44 +20504,74 @@ document.addEventListener('DOMContentLoaded', function(){
     try { return v.toLocaleString(undefined,{minimumFractionDigits:2, maximumFractionDigits:2}); }
     catch(e){ return v.toFixed(2); }
   }
+  function _domain(){
+    return (typeof window !== 'undefined' && window.payrollDomain) ? window.payrollDomain : null;
+  }
 
   // === Payroll ===
   function updatePayrollGrandTotals(){
     var tb = document.querySelector('#payrollTable tbody');
     var foot = document.querySelector('#payrollTotalsFoot');
     if (!tb || !foot) return;
-      var t = {regHrs:0, rate:0, regPay:0, adjHours:0, adjPay:0, otPay:0, adjAmt:0, grossPay:0, pagibig:0, philhealth:0, sss:0, loanSSS:0, loanPI:0, vale:0, valeWed:0, totalDed:0, netPay:0};
-    var div = Number(divisor) || 1;
+    var rows = [];
+    var t = {regHrs:0, rate:0, adjHours:0};
     tb.querySelectorAll('tr').forEach(function(tr){
-      t.regHrs   += _parse(_val(tr.querySelector('.regHrs')));
-      t.rate     += _parse(_val(tr.querySelector('.rate')));
-        t.regPay   += _parse(tr.querySelector('.regPay')?.textContent);
-        t.adjHours += _parse(tr.querySelector('.adjHours')?.textContent);
-        t.adjPay   += _parse(tr.querySelector('.adjPay')?.textContent);
-        t.otPay    += _parse(tr.querySelector('.otPay')?.textContent);
-        t.adjAmt   += _parse(tr.querySelector('.adjAmt')?.textContent);
-        t.grossPay += _parse(tr.querySelector('.grossPay')?.textContent);
-        const dedPagibig = readRowDeductionDataset(tr, 'pagibig', 'effective');
-        const dedPhilhealth = readRowDeductionDataset(tr, 'philhealth', 'effective');
-        const dedSss = readRowDeductionDataset(tr, 'sss', 'effective');
-        const dedLoanSss = readRowDeductionDataset(tr, 'loanSSS', 'effective');
-        const dedLoanPi = readRowDeductionDataset(tr, 'loanPI', 'effective');
-        const dedVale = readRowDeductionDataset(tr, 'vale', 'effective');
-        const dedValeWed = readRowDeductionDataset(tr, 'valeWed', 'effective');
-        const dedTotal = readRowDeductionDataset(tr, 'total', 'effective');
-        t.pagibig  += dedPagibig != null ? _parse(dedPagibig) : _parse(tr.querySelector('.pagibig')?.textContent);
-        t.philhealth += dedPhilhealth != null ? _parse(dedPhilhealth) : _parse(tr.querySelector('.philhealth')?.textContent);
-        t.sss      += dedSss != null ? _parse(dedSss) : _parse(tr.querySelector('.sss')?.textContent);
-        t.loanSSS  += dedLoanSss != null ? _parse(dedLoanSss) : (_parse(_val(tr.querySelector('.loanSSS'))) / div);
-        t.loanPI   += dedLoanPi != null ? _parse(dedLoanPi) : (_parse(_val(tr.querySelector('.loanPI'))) / div);
-        t.vale     += dedVale != null ? _parse(dedVale) : _parse(_val(tr.querySelector('.vale')));
-        t.valeWed  += dedValeWed != null ? _parse(dedValeWed) : _parse(_val(tr.querySelector('.valeWed')));
-        t.totalDed += dedTotal != null ? _parse(dedTotal) : _parse(tr.querySelector('.totalDed')?.textContent);
-        t.netPay   += _parse(tr.querySelector('.netPay')?.textContent);
+      t.regHrs += _parse(_val(tr.querySelector('.regHrs')));
+      t.rate += _parse(_val(tr.querySelector('.rate')));
+      t.adjHours += _parse(tr.querySelector('.adjHours')?.textContent);
+      rows.push({
+        regular_pay: _parse(tr.querySelector('.regPay')?.textContent),
+        overtime_pay: _parse(tr.querySelector('.otPay')?.textContent),
+        adjustment_pay: _parse(tr.querySelector('.adjPay')?.textContent),
+        additional_income_total: _parse(tr.querySelector('.adjAmt')?.textContent),
+        gross_pay: _parse(tr.querySelector('.grossPay')?.textContent),
+        total_deductions: _parse(tr.querySelector('.totalDed')?.textContent),
+        net_pay: _parse(tr.querySelector('.netPay')?.textContent),
+        pagibig_deduction: _parse(readRowDeductionDataset(tr, 'pagibig', 'effective')),
+        philhealth_deduction: _parse(readRowDeductionDataset(tr, 'philhealth', 'effective')),
+        sss_deduction: _parse(readRowDeductionDataset(tr, 'sss', 'effective')),
+        loan_sss_deduction: _parse(readRowDeductionDataset(tr, 'loanSSS', 'effective')),
+        loan_pagibig_deduction: _parse(readRowDeductionDataset(tr, 'loanPI', 'effective')),
+        other_deductions: _parse(readRowDeductionDataset(tr, 'adjustments', 'effective')),
+      });
     });
-    Object.keys(t).forEach(function(k){
+    var domain = _domain();
+    var totals = (domain && typeof domain.reducePayrollTotals === 'function')
+      ? domain.reducePayrollTotals(rows)
+      : rows.reduce(function(acc, row){
+        acc.gross_pay += _parse(row.gross_pay);
+        acc.total_deductions += _parse(row.total_deductions);
+        acc.net_pay += _parse(row.net_pay);
+        acc.regular_pay += _parse(row.regular_pay);
+        acc.overtime_pay += _parse(row.overtime_pay);
+        acc.adjustment_pay += _parse(row.adjustment_pay);
+        acc.additional_income_total += _parse(row.additional_income_total);
+        return acc;
+      }, {gross_pay:0,total_deductions:0,net_pay:0,regular_pay:0,overtime_pay:0,adjustment_pay:0,additional_income_total:0});
+    var dedTotals = (domain && typeof domain.reduceDeductionTotals === 'function')
+      ? domain.reduceDeductionTotals(rows)
+      : { pagibig:0, philhealth:0, sss:0, loanSSS:0, loanPI:0, other:0, total:totals.total_deductions };
+
+    var mapped = {
+      regHrs: t.regHrs,
+      rate: t.rate,
+      regPay: totals.regular_pay,
+      adjHours: t.adjHours,
+      adjPay: totals.adjustment_pay,
+      otPay: totals.overtime_pay,
+      adjAmt: totals.additional_income_total,
+      grossPay: totals.gross_pay,
+      pagibig: dedTotals.pagibig,
+      philhealth: dedTotals.philhealth,
+      sss: dedTotals.sss,
+      loanSSS: dedTotals.loanSSS,
+      loanPI: dedTotals.loanPI,
+      totalDed: totals.total_deductions,
+      netPay: totals.net_pay
+    };
+    Object.keys(mapped).forEach(function(k){
       var cell = foot.querySelector('[data-col="'+k+'"]');
-      if (cell) cell.textContent = _fmt(t[k]);
+      if (cell) cell.textContent = _fmt(mapped[k]);
     });
   }
   window.updatePayrollGrandTotals = updatePayrollGrandTotals;
@@ -20419,22 +20581,56 @@ document.addEventListener('DOMContentLoaded', function(){
     var tb = document.querySelector('#deductionsTable tbody');
     var foot = document.querySelector('#deductionsTable_foot');
     if (!tb || !foot) return;
-    var totalsRaw = {pagibig:0, philhealth:0, sss:0, loanSSS:0, loanPI:0, vale:0, adjustments:0, valeWed:0};
+    var rows = [];
     tb.querySelectorAll('tr').forEach(function(tr){
-      DEDUCTION_COLUMN_KEYS.forEach(function(key){
-        if (key === 'total') return;
-        var cell = tr.querySelector('[data-col="'+key+'"]');
-        if (!cell) return;
-        var rawAttr = cell.getAttribute('data-raw');
-        var rawVal = rawAttr != null ? parseFloat(rawAttr) : NaN;
-        if (!Number.isFinite(rawVal)) {
-          rawVal = _parse(cell.textContent || '');
-        }
-        if (!Number.isFinite(rawVal)) rawVal = 0;
-        totalsRaw[key] += rawVal;
+      rows.push({
+        pagibig_deduction: _parse(tr.querySelector('[data-col="pagibig"]')?.getAttribute('data-raw')),
+        philhealth_deduction: _parse(tr.querySelector('[data-col="philhealth"]')?.getAttribute('data-raw')),
+        sss_deduction: _parse(tr.querySelector('[data-col="sss"]')?.getAttribute('data-raw')),
+        loan_sss_deduction: _parse(tr.querySelector('[data-col="loanSSS"]')?.getAttribute('data-raw')),
+        loan_pagibig_deduction: _parse(tr.querySelector('[data-col="loanPI"]')?.getAttribute('data-raw')),
+        vale_deduction: _parse(tr.querySelector('[data-col="vale"]')?.getAttribute('data-raw')),
+        vale_wed_deduction: _parse(tr.querySelector('[data-col="valeWed"]')?.getAttribute('data-raw')),
+        other_deductions: _parse(tr.querySelector('[data-col="adjustments"]')?.getAttribute('data-raw')),
+        total_deductions: _parse(tr.querySelector('[data-col="total"]')?.getAttribute('data-raw')),
       });
     });
-    totalsRaw.total = roundToCents(Object.keys(totalsRaw).reduce(function(sum, key){ return sum + (key === 'total' ? 0 : totalsRaw[key]); }, 0));
+    var domain = _domain();
+    var reduced = (domain && typeof domain.reduceDeductionTotals === 'function')
+      ? domain.reduceDeductionTotals(rows)
+      : rows.reduce(function(acc, row){
+          acc.pagibig = roundToCents((acc.pagibig || 0) + _parse(row.pagibig_deduction));
+          acc.philhealth = roundToCents((acc.philhealth || 0) + _parse(row.philhealth_deduction));
+          acc.sss = roundToCents((acc.sss || 0) + _parse(row.sss_deduction));
+          acc.loanSSS = roundToCents((acc.loanSSS || 0) + _parse(row.loan_sss_deduction));
+          acc.loanPI = roundToCents((acc.loanPI || 0) + _parse(row.loan_pagibig_deduction));
+          acc.vale = roundToCents((acc.vale || 0) + _parse(row.vale_deduction));
+          acc.valeWed = roundToCents((acc.valeWed || 0) + _parse(row.vale_wed_deduction));
+          acc.other = roundToCents((acc.other || 0) + _parse(row.other_deductions));
+          acc.total = roundToCents((acc.total || 0) + _parse(row.total_deductions));
+          return acc;
+        }, {
+          pagibig: 0,
+          philhealth: 0,
+          sss: 0,
+          loanSSS: 0,
+          loanPI: 0,
+          vale: 0,
+          valeWed: 0,
+          other: 0,
+          total: 0
+        });
+    var totalsRaw = {
+      pagibig: roundToCents(reduced.pagibig || 0),
+      philhealth: roundToCents(reduced.philhealth || 0),
+      sss: roundToCents(reduced.sss || 0),
+      loanSSS: roundToCents(reduced.loanSSS || 0),
+      loanPI: roundToCents(reduced.loanPI || 0),
+      vale: roundToCents(reduced.vale || 0),
+      adjustments: roundToCents(reduced.other || 0),
+      valeWed: roundToCents(reduced.valeWed || 0),
+      total: roundToCents(reduced.total || 0)
+    };
     var effectiveTotals = computeEffectiveDeductionValues(totalsRaw);
     Object.keys(effectiveTotals).forEach(function(key){
       var cell = foot.querySelector('[data-col="'+key+'"]');

--- a/src/domain/payrollCalculations.js
+++ b/src/domain/payrollCalculations.js
@@ -1,31 +1,437 @@
-export function calculateGrossPay({ hourlyRate, regularHours, overtimeHours, overtimeMultiplier = 1.25 }) {
-  const regular = Number(hourlyRate || 0) * Number(regularHours || 0);
-  const overtime = Number(hourlyRate || 0) * Number(overtimeHours || 0) * Number(overtimeMultiplier || 0);
-  return regular + overtime;
+const DEFAULT_OT_MULTIPLIER = 1.25;
+const DEFAULT_ND_MULTIPLIER = 1.1;
+
+export function toNumber(value, fallback = 0) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+export function roundToCents(value) {
+  return Math.round(toNumber(value, 0) * 100) / 100;
+}
+
+function normalizePositiveNumber(value) {
+  return Math.max(0, toNumber(value, 0));
+}
+
+function normalizeRangeTable(rows, valueKey) {
+  if (!Array.isArray(rows)) return [];
+  return rows
+    .map((row) => ({
+      min: toNumber(row?.min, 0),
+      max: toNumber(row?.max, 0),
+      [valueKey]: toNumber(row?.[valueKey], 0),
+    }))
+    .sort((a, b) => a.min - b.min);
+}
+
+export function lookupBracketValue(monthlyIncome, rows, valueKey) {
+  const table = normalizeRangeTable(rows, valueKey);
+  if (!table.length) return 0;
+  const monthly = toNumber(monthlyIncome, 0);
+  if (monthly <= table[0].min) return toNumber(table[0][valueKey], 0);
+  for (const row of table) {
+    if (monthly >= row.min && monthly <= row.max) {
+      return toNumber(row[valueKey], 0);
+    }
+  }
+  return toNumber(table[table.length - 1][valueKey], 0);
+}
+
+export function loanSharePerPeriod(rawLoanAmount, divisor = 2) {
+  const loan = normalizePositiveNumber(rawLoanAmount);
+  const periods = Math.max(1, toNumber(divisor, 1));
+  return roundToCents(loan / periods);
+}
+
+export function normalizeAdditionalIncomeItems(items = []) {
+  if (!Array.isArray(items)) return [];
+  return items.map((item) => ({
+    ...item,
+    amount: roundToCents(normalizePositiveNumber(item?.amount)),
+  }));
+}
+
+export function totalAdditionalIncome(items = []) {
+  return roundToCents(normalizeAdditionalIncomeItems(items).reduce((sum, item) => sum + item.amount, 0));
+}
+
+export function normalizeOtherDeductionsItems(items = []) {
+  if (!Array.isArray(items)) return [];
+  return items.map((item) => ({
+    ...item,
+    amount: roundToCents(normalizePositiveNumber(item?.amount)),
+  }));
+}
+
+export function totalOtherDeductions(items = []) {
+  return roundToCents(normalizeOtherDeductionsItems(items).reduce((sum, item) => sum + item.amount, 0));
+}
+
+export function calculateOvertimePay({ hourlyRate, overtimeHours, overtimeMultiplier = DEFAULT_OT_MULTIPLIER }) {
+  const pay = toNumber(hourlyRate, 0) * toNumber(overtimeHours, 0) * toNumber(overtimeMultiplier, DEFAULT_OT_MULTIPLIER);
+  return roundToCents(pay);
+}
+
+export function calculateNightDifferentialPay({ hourlyRate, nightDiffHours = 0, nightDifferentialMultiplier = DEFAULT_ND_MULTIPLIER, precomputedNightDiffPay = null }) {
+  if (precomputedNightDiffPay != null) return roundToCents(precomputedNightDiffPay);
+  const premiumFactor = Math.max(0, toNumber(nightDifferentialMultiplier, DEFAULT_ND_MULTIPLIER) - 1);
+  return roundToCents(toNumber(hourlyRate, 0) * toNumber(nightDiffHours, 0) * premiumFactor);
+}
+
+export function normalizeNightDifferentialSettings(settings = {}) {
+  const raw = (settings && typeof settings === 'object') ? settings : {};
+  return {
+    // Default to enabled unless explicitly disabled.
+    // This prevents missing/null settings from silently zeroing valid ND pay.
+    enabled: raw.enabled !== false,
+    start: raw.start || '22:00',
+    end: raw.end || '06:00',
+    multiplier: Math.max(0, toNumber(raw.multiplier, DEFAULT_ND_MULTIPLIER)),
+  };
+}
+
+export function calculateNightDifferentialPayFromMinutes({ hourlyRate, nightDiffMinutes = 0, nightDifferentialMultiplier = DEFAULT_ND_MULTIPLIER }) {
+  const hours = toNumber(nightDiffMinutes, 0) / 60;
+  return calculateNightDifferentialPay({
+    hourlyRate,
+    nightDiffHours: hours,
+    nightDifferentialMultiplier,
+  });
+}
+
+export function resolveNightDifferentialPay({
+  hourlyRate,
+  nightDiffHours = 0,
+  nightDiffMinutes = 0,
+  precomputedNightDiffPay = null,
+  settings = null,
+  preferPrecomputed = true,
+} = {}) {
+  const ndSettings = normalizeNightDifferentialSettings(settings || {});
+  if (!ndSettings.enabled) {
+    return {
+      pay: 0,
+      source: 'disabled',
+      multiplier: ndSettings.multiplier,
+    };
+  }
+
+  if (preferPrecomputed && precomputedNightDiffPay != null) {
+    return {
+      pay: roundToCents(precomputedNightDiffPay),
+      source: 'precomputed',
+      multiplier: ndSettings.multiplier,
+    };
+  }
+
+  const pay = nightDiffMinutes > 0
+    ? calculateNightDifferentialPayFromMinutes({
+      hourlyRate,
+      nightDiffMinutes,
+      nightDifferentialMultiplier: ndSettings.multiplier,
+    })
+    : calculateNightDifferentialPay({
+      hourlyRate,
+      nightDiffHours,
+      nightDifferentialMultiplier: ndSettings.multiplier,
+      precomputedNightDiffPay: null,
+    });
+
+  return {
+    pay,
+    source: nightDiffMinutes > 0 ? 'minutes' : 'hours',
+    multiplier: ndSettings.multiplier,
+  };
+}
+
+export function calculatePrincipalLoanDeductionDecision({
+  active,
+  principal,
+  periodicAmount,
+  paidBefore = 0,
+  baseline = 0,
+  existingApplied = null,
+}) {
+  const isActive = active === true;
+  const principalAmount = roundToCents(Math.max(0, toNumber(principal, 0)));
+  const duePerPeriod = roundToCents(Math.max(0, toNumber(periodicAmount, 0)));
+  const paidBeforeAmount = roundToCents(Math.max(0, toNumber(paidBefore, 0)));
+  const baselineAmount = roundToCents(Math.max(0, toNumber(baseline, 0)));
+  const effectivePaidBefore = Math.max(0, roundToCents(paidBeforeAmount - baselineAmount));
+  const remainingBefore = roundToCents(principalAmount - effectivePaidBefore);
+
+  if (!isActive || principalAmount <= 0 || duePerPeriod <= 0) {
+    return {
+      shouldRun: false,
+      shouldDeactivate: false,
+      shouldClear: true,
+      desired: 0,
+      scheduled: existingApplied == null ? null : roundToCents(existingApplied),
+      remainingBefore,
+    };
+  }
+
+  if (remainingBefore <= 0) {
+    return {
+      shouldRun: false,
+      shouldDeactivate: true,
+      shouldClear: true,
+      desired: 0,
+      scheduled: 0,
+      remainingBefore: 0,
+    };
+  }
+
+  const desired = roundToCents(Math.min(duePerPeriod, remainingBefore));
+  return {
+    shouldRun: true,
+    shouldDeactivate: false,
+    shouldClear: desired <= 0,
+    desired,
+    scheduled: existingApplied == null ? null : roundToCents(existingApplied),
+    remainingBefore,
+  };
+}
+
+export function calculatePagibigLoanPerPeriod({ active, monthly, divisor = 2 }) {
+  if (active !== true) return 0;
+  return roundToCents(Math.max(0, toNumber(monthly, 0)) / Math.max(1, toNumber(divisor, 1)));
+}
+
+export function calculateContributionDeductions({ regularPay = 0, hourlyRate = 0, divisor = 2, flags = {}, hasCompensation = true, sssTable = [], pagibigTable = [], philhealthTable = [] }) {
+  const monthly = toNumber(hourlyRate, 0) * 8 * 24;
+  const safeDivisor = Math.max(1, toNumber(divisor, 1));
+  const pagibigRate = lookupBracketValue(monthly, pagibigTable, 'rate');
+  const philhealthRate = lookupBracketValue(monthly, philhealthTable, 'rate');
+  const sssEmployeeShare = lookupBracketValue(monthly, sssTable, 'employee');
+
+  const pagibig = hasCompensation && flags.pagibig !== false ? roundToCents(toNumber(regularPay, 0) * pagibigRate) : 0;
+  const philhealth = hasCompensation && flags.philhealth !== false ? roundToCents(toNumber(regularPay, 0) * philhealthRate) : 0;
+  const sss = hasCompensation && flags.sss !== false ? roundToCents(sssEmployeeShare / safeDivisor) : 0;
+
+  return {
+    monthly,
+    pagibigRate,
+    philhealthRate,
+    sssEmployeeShare,
+    pagibig,
+    philhealth,
+    sss,
+  };
+}
+
+export function calculateLoanDeductions({ loanSSS = 0, loanPI = 0, divisor = 2, hasWorkedTime = true, applyLoansWithoutWorkedTime = false }) {
+  const safeDivisor = Math.max(1, toNumber(divisor, 1));
+  const allow = applyLoansWithoutWorkedTime || hasWorkedTime;
+  return {
+    loanSSS: allow ? roundToCents(toNumber(loanSSS, 0) / safeDivisor) : 0,
+    loanPI: allow ? roundToCents(toNumber(loanPI, 0) / safeDivisor) : 0,
+  };
+}
+
+export function buildPayrollRow(input = {}) {
+  const {
+    employeeId,
+    regularHours = 0,
+    overtimeHours = 0,
+    regularAdjustmentHours = 0,
+    overtimeAdjustmentHours = 0,
+    hourlyRate = 0,
+    overtimeMultiplier = DEFAULT_OT_MULTIPLIER,
+    nightDiffHours = 0,
+    nightDiffMinutes = 0,
+    nightDiffPay = 0,
+    nightDifferentialMultiplier = DEFAULT_ND_MULTIPLIER,
+    nightDifferentialSettings = null,
+    additionalIncomeTotal = 0,
+    otherDeductionsTotal = 0,
+    loanSSS = 0,
+    loanPI = 0,
+    vale = 0,
+    valeWed = 0,
+    divisor = 2,
+    contributionFlags = {},
+    sssTable = [],
+    pagibigTable = [],
+    philhealthTable = [],
+    applyLoansWithoutWorkedTime = false,
+  } = input;
+
+  const regHours = toNumber(regularHours, 0);
+  const otHours = toNumber(overtimeHours, 0) + toNumber(overtimeAdjustmentHours, 0);
+  const regAdjHours = toNumber(regularAdjustmentHours, 0);
+  const rate = toNumber(hourlyRate, 0);
+
+  const regularPay = roundToCents(regHours * rate);
+  const adjustmentPay = roundToCents(regAdjHours * rate);
+  const overtimePayBase = calculateOvertimePay({ hourlyRate: rate, overtimeHours: otHours, overtimeMultiplier });
+  const ndResolution = resolveNightDifferentialPay({
+    hourlyRate: rate,
+    nightDiffHours,
+    nightDiffMinutes,
+    precomputedNightDiffPay: nightDiffPay,
+    settings: nightDifferentialSettings || { multiplier: nightDifferentialMultiplier, enabled: true },
+    preferPrecomputed: true,
+  });
+  const nightDiffComputed = ndResolution.pay;
+  const overtimePay = roundToCents(overtimePayBase + nightDiffComputed);
+
+  const normalizedAdditionalIncome = roundToCents(normalizePositiveNumber(additionalIncomeTotal));
+  const normalizedOtherDeductions = roundToCents(normalizePositiveNumber(otherDeductionsTotal));
+
+  const grossPay = roundToCents(regularPay + adjustmentPay + overtimePay + normalizedAdditionalIncome);
+  const hasWorkedTime = regHours > 0 || otHours > 0 || regAdjHours > 0;
+  const hasCompensation = hasWorkedTime || normalizedAdditionalIncome > 0;
+
+  const contributions = calculateContributionDeductions({
+    regularPay,
+    hourlyRate: rate,
+    divisor,
+    flags: contributionFlags,
+    hasCompensation,
+    sssTable,
+    pagibigTable,
+    philhealthTable,
+  });
+
+  const loans = calculateLoanDeductions({
+    loanSSS,
+    loanPI,
+    divisor,
+    hasWorkedTime,
+    applyLoansWithoutWorkedTime,
+  });
+
+  const deductionParts = {
+    pagibig: contributions.pagibig,
+    philhealth: contributions.philhealth,
+    sss: contributions.sss,
+    loanSSS: loans.loanSSS,
+    loanPI: loans.loanPI,
+    vale: roundToCents(toNumber(vale, 0)),
+    valeWed: roundToCents(toNumber(valeWed, 0)),
+    otherDeductions: normalizedOtherDeductions,
+  };
+
+  const totalDeductions = roundToCents(
+    deductionParts.pagibig + deductionParts.philhealth + deductionParts.sss + deductionParts.loanSSS + deductionParts.loanPI + deductionParts.vale + deductionParts.valeWed + deductionParts.otherDeductions,
+  );
+
+  return {
+    employee_id: employeeId,
+    regular_hours: regHours,
+    overtime_hours: otHours,
+    night_diff_hours: toNumber(nightDiffHours, 0),
+    hourly_rate: rate,
+    regular_pay: regularPay,
+    overtime_pay_base: overtimePayBase,
+    night_diff_pay: nightDiffComputed,
+    overtime_pay: overtimePay,
+    adjustment_hours: regAdjHours,
+    adjustment_pay: adjustmentPay,
+    additional_income_total: normalizedAdditionalIncome,
+    gross_pay: grossPay,
+    pagibig_deduction: deductionParts.pagibig,
+    philhealth_deduction: deductionParts.philhealth,
+    sss_deduction: deductionParts.sss,
+    loan_sss_deduction: deductionParts.loanSSS,
+    loan_pagibig_deduction: deductionParts.loanPI,
+    vale_deduction: deductionParts.vale,
+    vale_wed_deduction: deductionParts.valeWed,
+    other_deductions: deductionParts.otherDeductions,
+    total_deductions: totalDeductions,
+    net_pay: roundToCents(grossPay - totalDeductions),
+  };
+}
+
+export function reducePayrollTotals(rows = []) {
+  return rows.reduce((totals, row) => {
+    totals.gross_pay = roundToCents(totals.gross_pay + toNumber(row?.gross_pay, 0));
+    totals.total_deductions = roundToCents(totals.total_deductions + toNumber(row?.total_deductions, 0));
+    totals.net_pay = roundToCents(totals.net_pay + toNumber(row?.net_pay, 0));
+    totals.regular_pay = roundToCents(totals.regular_pay + toNumber(row?.regular_pay, 0));
+    totals.overtime_pay = roundToCents(totals.overtime_pay + toNumber(row?.overtime_pay, 0));
+    totals.adjustment_pay = roundToCents(totals.adjustment_pay + toNumber(row?.adjustment_pay, 0));
+    totals.additional_income_total = roundToCents(totals.additional_income_total + toNumber(row?.additional_income_total, 0));
+    return totals;
+  }, {
+    gross_pay: 0,
+    total_deductions: 0,
+    net_pay: 0,
+    regular_pay: 0,
+    overtime_pay: 0,
+    adjustment_pay: 0,
+    additional_income_total: 0,
+  });
+}
+
+export function reduceOvertimeTotals(rows = []) {
+  return rows.reduce((totals, row) => {
+    totals.overtime_hours = roundToCents(totals.overtime_hours + toNumber(row?.overtime_hours, 0));
+    totals.night_diff_pay = roundToCents(totals.night_diff_pay + toNumber(row?.night_diff_pay, 0));
+    totals.overtime_pay = roundToCents(totals.overtime_pay + toNumber(row?.overtime_pay, 0));
+    return totals;
+  }, {
+    overtime_hours: 0,
+    night_diff_pay: 0,
+    overtime_pay: 0,
+  });
+}
+
+export function reduceDeductionTotals(rows = []) {
+  return rows.reduce((totals, row) => {
+    totals.pagibig = roundToCents(totals.pagibig + toNumber(row?.pagibig_deduction, 0));
+    totals.philhealth = roundToCents(totals.philhealth + toNumber(row?.philhealth_deduction, 0));
+    totals.sss = roundToCents(totals.sss + toNumber(row?.sss_deduction, 0));
+    totals.loanSSS = roundToCents(totals.loanSSS + toNumber(row?.loan_sss_deduction, 0));
+    totals.loanPI = roundToCents(totals.loanPI + toNumber(row?.loan_pagibig_deduction, 0));
+    totals.vale = roundToCents(totals.vale + toNumber(row?.vale_deduction, 0));
+    totals.valeWed = roundToCents(totals.valeWed + toNumber(row?.vale_wed_deduction, 0));
+    totals.other = roundToCents(totals.other + toNumber(row?.other_deductions, 0));
+    totals.total = roundToCents(totals.total + toNumber(row?.total_deductions, 0));
+    return totals;
+  }, {
+    pagibig: 0,
+    philhealth: 0,
+    sss: 0,
+    loanSSS: 0,
+    loanPI: 0,
+    vale: 0,
+    valeWed: 0,
+    other: 0,
+    total: 0,
+  });
+}
+
+export function calculateGrossPay({ hourlyRate, regularHours, overtimeHours, overtimeMultiplier = DEFAULT_OT_MULTIPLIER }) {
+  const regular = toNumber(hourlyRate, 0) * toNumber(regularHours, 0);
+  const overtime = toNumber(hourlyRate, 0) * toNumber(overtimeHours, 0) * toNumber(overtimeMultiplier, DEFAULT_OT_MULTIPLIER);
+  return roundToCents(regular + overtime);
 }
 
 export function calculatePayrollRow({ employee, attendance, loanDeductions = 0, contributionDeductions = 0 }) {
-  const regularHours = Number(attendance?.regular_hours || 0);
-  const overtimeHours = Number(attendance?.overtime_hours || 0);
+  const regularHours = toNumber(attendance?.regular_hours, 0);
+  const overtimeHours = toNumber(attendance?.overtime_hours, 0);
   const hasWorkedTime = regularHours + overtimeHours > 0;
 
   const grossPay = calculateGrossPay({
-    hourlyRate: employee.hourly_rate,
+    hourlyRate: employee?.hourly_rate,
     regularHours,
     overtimeHours,
-    overtimeMultiplier: employee.overtime_multiplier || 1.25,
+    overtimeMultiplier: employee?.overtime_multiplier || DEFAULT_OT_MULTIPLIER,
   });
 
-  const effectiveLoanDeductions = hasWorkedTime ? Number(loanDeductions || 0) : 0;
-  const effectiveContributionDeductions = Number(contributionDeductions || 0);
+  const effectiveLoanDeductions = hasWorkedTime ? toNumber(loanDeductions, 0) : 0;
+  const effectiveContributionDeductions = toNumber(contributionDeductions, 0);
 
   const netPay = grossPay - effectiveLoanDeductions - effectiveContributionDeductions;
 
   return {
-    employee_id: employee.id,
-    gross_pay: grossPay,
-    loan_deductions: effectiveLoanDeductions,
-    contribution_deductions: effectiveContributionDeductions,
-    net_pay: netPay,
+    employee_id: employee?.id,
+    gross_pay: roundToCents(grossPay),
+    loan_deductions: roundToCents(effectiveLoanDeductions),
+    contribution_deductions: roundToCents(effectiveContributionDeductions),
+    net_pay: roundToCents(netPay),
   };
 }

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { setCurrentPeriod, setSupabaseConnected } from './state/store.js';
 import { startRealtimeSubscriptions } from './realtime/subscriptions.js';
 import { mountPayrollController } from './ui/payrollController.js';
 import { waitForSupabaseClient } from './config/supabaseClient.js';
+import * as payrollDomain from './domain/payrollCalculations.js';
 
 let cleanupUi = null;
 let cleanupRealtime = null;
@@ -153,6 +154,12 @@ try {
   installDevLocalStorageDetector();
 } catch (error) {
   console.warn('initial localStorage diagnostic hook failed', error);
+}
+
+try {
+  window.payrollDomain = payrollDomain;
+} catch (error) {
+  console.warn('failed to expose payrollDomain', error);
 }
 
 if (document.readyState === 'loading') {

--- a/tests/payrollDomain.test.mjs
+++ b/tests/payrollDomain.test.mjs
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import {
+  buildPayrollRow,
+  reducePayrollTotals,
+  reduceDeductionTotals,
+  reduceOvertimeTotals,
+  resolveNightDifferentialPay,
+  calculatePrincipalLoanDeductionDecision,
+  calculatePagibigLoanPerPeriod,
+  totalAdditionalIncome,
+  totalOtherDeductions,
+} from '../src/domain/payrollCalculations.js';
+
+const sssTable = [{ min: 0, max: 1e9, employee: 1000 }];
+const pagibigTable = [{ min: 0, max: 1e9, rate: 0.02 }];
+const philhealthTable = [{ min: 0, max: 1e9, rate: 0.025 }];
+
+// regular pay only
+const regularOnly = buildPayrollRow({
+  employeeId: 'E1', regularHours: 40, hourlyRate: 100, divisor: 2,
+  sssTable, pagibigTable, philhealthTable,
+});
+assert.equal(regularOnly.regular_pay, 4000);
+assert.equal(regularOnly.overtime_pay, 0);
+
+// regular + OT + ND
+const withOt = buildPayrollRow({
+  employeeId: 'E2', regularHours: 40, overtimeHours: 5, hourlyRate: 100,
+  overtimeMultiplier: 1.25, nightDiffPay: 50, divisor: 2,
+  sssTable, pagibigTable, philhealthTable,
+});
+assert.equal(withOt.overtime_pay_base, 625);
+assert.equal(withOt.night_diff_pay, 50);
+assert.equal(withOt.overtime_pay, 675);
+
+// ND computation can be centralized from minute overlap input
+const ndFromMinutes = resolveNightDifferentialPay({
+  hourlyRate: 100,
+  nightDiffMinutes: 120,
+  settings: { enabled: true, multiplier: 1.1 },
+  preferPrecomputed: false,
+});
+assert.equal(ndFromMinutes.pay, 20);
+assert.equal(ndFromMinutes.source, 'minutes');
+
+const ndDisabled = resolveNightDifferentialPay({
+  hourlyRate: 100,
+  nightDiffMinutes: 120,
+  settings: { enabled: false, multiplier: 1.5 },
+  precomputedNightDiffPay: 999,
+  preferPrecomputed: true,
+});
+assert.equal(ndDisabled.pay, 0);
+assert.equal(ndDisabled.source, 'disabled');
+
+const ndMissingSettingsStillUsesPrecomputed = resolveNightDifferentialPay({
+  hourlyRate: 100,
+  precomputedNightDiffPay: 55,
+  settings: null,
+  preferPrecomputed: true,
+});
+assert.equal(ndMissingSettingsStillUsesPrecomputed.pay, 55);
+assert.equal(ndMissingSettingsStillUsesPrecomputed.source, 'precomputed');
+
+// additional income and other deductions
+const incomeItemsTotal = totalAdditionalIncome([{ amount: '100' }, { amount: -20 }, { amount: 50 }]);
+const otherDedTotal = totalOtherDeductions([{ amount: '40' }, { amount: -5 }]);
+assert.equal(incomeItemsTotal, 150);
+assert.equal(otherDedTotal, 40);
+
+const withIncomeAndDeds = buildPayrollRow({
+  employeeId: 'E3', regularHours: 40, hourlyRate: 100,
+  additionalIncomeTotal: incomeItemsTotal,
+  otherDeductionsTotal: otherDedTotal,
+  sssTable, pagibigTable, philhealthTable,
+});
+assert.equal(withIncomeAndDeds.additional_income_total, 150);
+assert.equal(withIncomeAndDeds.other_deductions, 40);
+
+// contribution flags disable selected contributions
+const withFlags = buildPayrollRow({
+  employeeId: 'E4', regularHours: 40, hourlyRate: 100,
+  contributionFlags: { pagibig: false, philhealth: true, sss: false },
+  sssTable, pagibigTable, philhealthTable,
+});
+assert.equal(withFlags.pagibig_deduction, 0);
+assert.equal(withFlags.sss_deduction, 0);
+assert.ok(withFlags.philhealth_deduction > 0);
+
+// loans with and without worked time behavior
+const noWork = buildPayrollRow({
+  employeeId: 'E5', loanSSS: 200, loanPI: 100, divisor: 2,
+  sssTable, pagibigTable, philhealthTable,
+});
+assert.equal(noWork.loan_sss_deduction, 0);
+assert.equal(noWork.loan_pagibig_deduction, 0);
+
+const noWorkButApplyLoans = buildPayrollRow({
+  employeeId: 'E6', loanSSS: 200, loanPI: 100, divisor: 2,
+  applyLoansWithoutWorkedTime: true,
+  sssTable, pagibigTable, philhealthTable,
+});
+assert.equal(noWorkButApplyLoans.loan_sss_deduction, 100);
+assert.equal(noWorkButApplyLoans.loan_pagibig_deduction, 50);
+
+// tracker-style principal decisioning handles remaining balance and stop-at-zero
+const loanDecision = calculatePrincipalLoanDeductionDecision({
+  active: true,
+  principal: 1000,
+  periodicAmount: 300,
+  paidBefore: 900,
+  baseline: 0,
+  existingApplied: null,
+});
+assert.equal(loanDecision.desired, 100);
+assert.equal(loanDecision.shouldDeactivate, false);
+
+const loanDoneDecision = calculatePrincipalLoanDeductionDecision({
+  active: true,
+  principal: 1000,
+  periodicAmount: 300,
+  paidBefore: 1000,
+  baseline: 0,
+  existingApplied: null,
+});
+assert.equal(loanDoneDecision.shouldRun, false);
+assert.equal(loanDoneDecision.shouldDeactivate, true);
+
+assert.equal(calculatePagibigLoanPerPeriod({ active: true, monthly: 500, divisor: 2 }), 250);
+
+// adjustment hours affect result
+const withAdjustment = buildPayrollRow({
+  employeeId: 'E7', regularHours: 40, regularAdjustmentHours: 2, hourlyRate: 100,
+  sssTable, pagibigTable, philhealthTable,
+});
+assert.equal(withAdjustment.adjustment_pay, 200);
+
+// zero-work scenario keeps contributions at 0 with no compensation
+const zeroWork = buildPayrollRow({
+  employeeId: 'E8', regularHours: 0, overtimeHours: 0, hourlyRate: 100,
+  sssTable, pagibigTable, philhealthTable,
+});
+assert.equal(zeroWork.pagibig_deduction, 0);
+assert.equal(zeroWork.philhealth_deduction, 0);
+assert.equal(zeroWork.sss_deduction, 0);
+
+// totals reducers
+const totals = reducePayrollTotals([regularOnly, withOt]);
+assert.equal(totals.gross_pay, regularOnly.gross_pay + withOt.gross_pay);
+const dedTotals = reduceDeductionTotals([regularOnly, withOt]);
+assert.equal(dedTotals.total, regularOnly.total_deductions + withOt.total_deductions);
+const otTotals = reduceOvertimeTotals([regularOnly, withOt]);
+assert.equal(otTotals.overtime_pay, regularOnly.overtime_pay + withOt.overtime_pay);
+
+const deductionRows = [
+  { vale_deduction: 100, vale_wed_deduction: 50, total_deductions: 150 },
+  { vale_deduction: 20, vale_wed_deduction: 30, total_deductions: 50 },
+];
+const withValeTotals = reduceDeductionTotals(deductionRows);
+assert.equal(withValeTotals.vale, 120);
+assert.equal(withValeTotals.valeWed, 80);
+
+const rowWithVale = buildPayrollRow({
+  employeeId: 'E9',
+  regularHours: 40,
+  hourlyRate: 100,
+  vale: 100,
+  valeWed: 25,
+  sssTable,
+  pagibigTable,
+  philhealthTable,
+});
+const combinedTotals = reduceDeductionTotals([rowWithVale]);
+assert.equal(combinedTotals.vale, rowWithVale.vale_deduction);
+assert.equal(combinedTotals.valeWed, rowWithVale.vale_wed_deduction);
+
+console.log('payrollDomain tests passed');


### PR DESCRIPTION
### Motivation
- Centralize payroll and deduction logic into a reusable domain module to improve correctness and make calculation behavior pluggable. 
- Allow UI code to delegate complex rules (night differential, loan decisioning, contribution/loan calculations and reductions) to a single well-tested implementation. 

### Description
- Add `src/domain/payrollCalculations.js` which implements normalized helpers and core functions such as `buildPayrollRow`, `calculateNightDifferentialPay`, `calculatePrincipalLoanDeductionDecision`, `calculateContributionDeductions`, `reducePayrollTotals`, `reduceDeductionTotals`, and `reduceOvertimeTotals` plus utility functions like `roundToCents`. 
- Update `src/main.js` to import the domain and expose it as `window.payrollDomain` so legacy UI code can call domain functions. 
- Integrate the domain into `index.html` by delegating night differential calculation, loan tracker decisioning, additional income/other-deduction totals, per-row payroll construction (`computePayrollDomainRow`), and totals/reduction logic to the domain where available. 
- Add comprehensive unit tests `tests/payrollDomain.test.mjs` that exercise `buildPayrollRow`, reducers, night-differential resolution, loan decisioning, and totals aggregation. 

### Testing
- Run the new unit test suite `tests/payrollDomain.test.mjs` (Node) which asserts expected values for payroll rows, ND resolution, loan decisions, totals reducers, and additional/other deductions; all assertions passed and the test prints `payrollDomain tests passed`.
- No other automated test failures were reported during the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b20a52f4f483289fd429fa136685a4)