### PR TITLE
Persist critical payroll keys to cloud KV, add migration & diagnostics

### DIFF
--- a/index.html
+++ b/index.html
@@ -2345,7 +2345,7 @@ window.addEventListener('load', dashReports);
           window.storedEmployees = supaVal;
         } else {
           // fallback to localStorage
-          window.storedEmployees = JSON.parse(localStorage.getItem('att_employees_v2') || '{}');
+          window.storedEmployees = (window.cacheGet ? window.cacheGet('att_employees_v2', {}) : JSON.parse(localStorage.getItem('att_employees_v2') || '{}'));
         }
       }
       // Attendance records store (att_records_v2)
@@ -2364,7 +2364,7 @@ window.addEventListener('load', dashReports);
         if (supaVal !== undefined) {
           window.storedProjects = supaVal;
         } else {
-          window.storedProjects = JSON.parse(localStorage.getItem('att_projects_v1') || '{}');
+          window.storedProjects = (window.cacheGet ? window.cacheGet('att_projects_v1', {}) : JSON.parse(localStorage.getItem('att_projects_v1') || '{}'));
         }
       }
       // Schedules store (att_schedules_v2) – ensures schedules are available early
@@ -2373,7 +2373,7 @@ window.addEventListener('load', dashReports);
         if (supaVal !== undefined) {
           window.storedSchedules = supaVal;
         } else {
-          window.storedSchedules = JSON.parse(localStorage.getItem('att_schedules_v2') || '{}');
+          window.storedSchedules = (window.cacheGet ? window.cacheGet('att_schedules_v2', {}) : JSON.parse(localStorage.getItem('att_schedules_v2') || '{}'));
         }
       }
     } catch (e) {
@@ -3157,7 +3157,7 @@ window.addEventListener('load', dashReports);
 
      </table>
      <div class="section note">
-      Reads employees from localStorage key
+      Reads employees from synchronized cloud payroll store key
       <code>
        att_employees_v2
       </code>
@@ -3312,7 +3312,7 @@ window.addEventListener('load', dashReports);
        <label class="loan-tracker-toggle"><input type="checkbox" id="loanTrackerActiveOnly" /> Active loans only</label>
        <button type="button" id="applyLoanTrackerBtn">Apply tracker to current period</button>
        <button type="button" id="recalcLoanTrackerBtn">Recalculate current period</button>
-       <span class="save-indicator" id="loanTrackerSaveStatus">Saved locally</span>
+       <span class="save-indicator" id="loanTrackerSaveStatus">Saved to cloud</span>
       </div>
       <div class="table-wrap">
        <table id="loanTrackerTable">
@@ -3385,7 +3385,7 @@ window.addEventListener('load', dashReports);
              <button type="button" id="printOtherDeductionsPivotBtn">Print Report</button>
        <button type="button" id="exportOtherDeductionsPivotExcelBtn">Download Excel</button>
 </div>
-      <span class="save-indicator" id="otherDeductionsSaveStatus" aria-live="polite">Saved locally</span>
+      <span class="save-indicator" id="otherDeductionsSaveStatus" aria-live="polite">Saved to cloud</span>
      </div>
      <table id="otherDeductionsTable">
       <thead>
@@ -3468,6 +3468,52 @@ let bantayProj = {};
 })();
 // LocalStorage key for per-employee contribution flags (Pag-IBIG, PhilHealth, SSS)
 const LS_CONTRIB_FLAGS='payroll_contrib_flags';
+
+const CRITICAL_PAYROLL_KEYS = new Set([
+  'att_employees_v2','att_projects_v1','att_schedules_v2','att_schedules_default','att_records_v2',
+  'payroll_loan_tracker','payroll_loan_sss','payroll_loan_pagibig','payroll_vale','payroll_vale_wed',
+  'payroll_contrib_flags','payroll_lock_state','payroll_rates','payroll_hist',
+  'payroll_other_deductions_details','payroll_other_deductions_total',
+  'payroll_additional_income_details','payroll_additional_income_total'
+]);
+
+async function persistCriticalBusinessKey(key, value) {
+  if (!CRITICAL_PAYROLL_KEYS.has(key)) {
+    if (typeof window.writeKV === 'function') return window.writeKV(key, value);
+    if (typeof window.sharedSet === 'function') return window.sharedSet(key, value);
+    return false;
+  }
+
+  const writer = (typeof window.writeKV === 'function') ? window.writeKV :
+    ((typeof window.sharedSet === 'function') ? window.sharedSet : null);
+
+  if (!writer) {
+    const msg = `[payroll:persistence] critical key ${key} has no cloud writer`; 
+    if (window.__PAYROLL_STRICT_LOCAL_DEPRECATION) throw new Error(msg);
+    console.warn(msg);
+    return false;
+  }
+
+  try {
+    const out = await writer(key, value);
+    if (out === false) {
+      const warn = `[payroll:persistence] writer reported non-authoritative write for ${key}`;
+      if (window.__PAYROLL_STRICT_LOCAL_DEPRECATION) throw new Error(warn);
+      console.warn(warn);
+    }
+    return out !== false;
+  } catch (error) {
+    if (window.__PAYROLL_STRICT_LOCAL_DEPRECATION) throw error;
+    console.warn('[payroll:persistence] critical write failed', key, error?.message || error);
+    return false;
+  }
+}
+
+function persistCriticalBusinessKeySoon(key, value) {
+  persistCriticalBusinessKey(key, value).catch((error) => {
+    console.warn('[payroll:persistence] deferred critical write failed', key, error?.message || error);
+  });
+}
 const PAYROLL_SETTINGS_KEY = 'settings_payroll';
 const DEFAULT_PAYROLL_SETTINGS = {
   overtime: { multiplier: 1.25 },
@@ -4265,8 +4311,7 @@ function loadContribFlagsFromLocalStorage() {
 function persistContribFlags() {
   const normalized = normalizeContribFlags(contribFlags);
   contribFlags = normalized;
-  try { if (window.cacheSet) window.cacheSet(LS_CONTRIB_FLAGS, normalized); else localStorage.setItem(LS_CONTRIB_FLAGS, JSON.stringify(normalized)); } catch (_) {}
-  try { if (typeof window.sharedSet === 'function') window.sharedSet(LS_CONTRIB_FLAGS, normalized); } catch (_) {}
+  persistCriticalBusinessKeySoon(LS_CONTRIB_FLAGS, normalized);
 }
 
 async function refreshContribFlagsFromStore() {
@@ -4280,17 +4325,21 @@ async function refreshContribFlagsFromStore() {
 
   const localHasData = Object.keys(localFlags).length > 0;
   const cloudHasData = !!cloudFlags && Object.keys(cloudFlags).length > 0;
+  const hasExplicitPending = !!(window.__sharedSyncState && window.__sharedSyncState.offline);
 
-  if (cloudHasData) {
-    // Merge conservatively: keep cloud as baseline but let current local state win
-    // for overlapping employee IDs to prevent immediate F5 reverts.
-    contribFlags = { ...cloudFlags, ...localFlags };
-  } else {
-    contribFlags = localFlags;
+  if (cloudHasData && !hasExplicitPending) {
+    contribFlags = cloudFlags;
+    return;
   }
 
-  // Normalize/persist whichever state we chose so local and cloud converge.
-  if (cloudHasData || localHasData) persistContribFlags();
+  if (cloudHasData && hasExplicitPending) {
+    contribFlags = { ...cloudFlags, ...localFlags };
+    persistContribFlags();
+    return;
+  }
+
+  contribFlags = localFlags;
+  if (localHasData) persistContribFlags();
 }
 
 let contribFlags = loadContribFlagsFromLocalStorage();
@@ -4622,7 +4671,7 @@ function migrateLoanTrackerLegacy(obj){
 }
 function loadLoanTrackerFromStorage(){
   let parsed = null;
-  try { parsed = JSON.parse(localStorage.getItem(LS_LOAN_TRACKER) || 'null'); } catch(_){ parsed = null; }
+  try { parsed = (window.cacheGet ? window.cacheGet(LS_LOAN_TRACKER, null) : JSON.parse(localStorage.getItem(LS_LOAN_TRACKER) || 'null')); } catch(_){ parsed = null; }
   parsed = ensureLoanTrackerShape(parsed);
   parsed = migrateLoanTrackerLegacy(parsed);
   return parsed;
@@ -4644,7 +4693,7 @@ async function persistLoanTracker(){
 
   // No-op if nothing changed since last save (prevents bumping timestamps / noisy realtime updates)
   try {
-    const curStr = localStorage.getItem(LS_LOAN_TRACKER);
+    const curStr = JSON.stringify(window.cacheGet ? window.cacheGet(LS_LOAN_TRACKER, null) : null);
     const nextStrNoMetaBump = JSON.stringify(loanTracker);
     if (curStr && curStr === nextStrNoMetaBump) return;
   } catch(_){}
@@ -4656,7 +4705,7 @@ async function persistLoanTracker(){
   } catch(_){}
 
   let savedStr = null;
-  try { savedStr = JSON.stringify(loanTracker); localStorage.setItem(LS_LOAN_TRACKER, savedStr); } catch(_){}
+  try { savedStr = JSON.stringify(loanTracker); } catch(_){}
 
   // KV sync (realtime across devices): write to kv_store using writeKV, debounced.
   try {
@@ -4882,12 +4931,12 @@ async function persistLoanTracker(){
 function persistLoanTrackerLocalCache(){
   try {
     ensureLoanTrackerShape(loanTracker);
-    const curStr = localStorage.getItem(LS_LOAN_TRACKER);
+    const curStr = JSON.stringify(window.cacheGet ? window.cacheGet(LS_LOAN_TRACKER, null) : null);
     const nextStrNoMetaBump = JSON.stringify(loanTracker);
     if (curStr && curStr === nextStrNoMetaBump) return;
     loanTracker.__meta = loanTracker.__meta || {};
     loanTracker.__meta.lastUpdatedAt = Date.now();
-    localStorage.setItem(LS_LOAN_TRACKER, JSON.stringify(loanTracker));
+    persistCriticalBusinessKeySoon(LS_LOAN_TRACKER, loanTracker);
   } catch(_){ }
 }
 
@@ -5015,7 +5064,7 @@ async function loadLoanTrackerFromSupabaseTables(){
     loanTracker = migrateLoanTrackerLegacy(next);
     try { window.loanTracker = loanTracker; } catch(_){}
     // local cache only
-    try { localStorage.setItem(LS_LOAN_TRACKER, JSON.stringify(loanTracker)); } catch(_){}
+    try { persistCriticalBusinessKeySoon(LS_LOAN_TRACKER, loanTracker); } catch(_){ }
 
     try { applyLoanTrackerToPeriod(currentPeriodKey || periodKey(), { createEntries: true, updateMaps: true }); } catch(_){}
     try { saveCurrentPeriodDeductions(); } catch(_){}
@@ -6740,7 +6789,7 @@ const loanTrackerRefresh = (() => {
 
     try { applyLoanTrackerToPeriod(currentPeriodKey || periodKey(), baseOpts); } catch(_) {}
     try { saveCurrentPeriodDeductions(); } catch(_) {}
-    try { await persistLoanTracker(); setStatus('Saved locally', 'saved'); } catch(e){ setStatus('Save failed', 'error'); }
+    try { await persistLoanTracker(); setStatus('Saved to cloud', 'saved'); } catch(e){ setStatus('Save failed', 'error'); }
 
     // While typing, avoid expensive full-page recalcs and table re-renders that can cause lag/caret jumps.
     if (mode === 'full') {
@@ -7617,7 +7666,7 @@ function attachRowEvents(){
           valeWed[id] = +(Number(vWI.value)||0).toFixed(2);
         }
         if (window.cacheSet) window.cacheSet(LS_REG_HRS, regHours); else localStorage.setItem(LS_REG_HRS, JSON.stringify(regHours));
-        if (window.sharedSet) window.sharedSet(LS_RATES, payrollRates); else localStorage.setItem(LS_RATES, JSON.stringify(payrollRates));
+        persistCriticalBusinessKeySoon(LS_RATES, payrollRates);
         saveCurrentPeriodDeductions();
         if (typeof renderDeductionsTable === 'function') renderDeductionsTable();
         calculateRow(row);
@@ -8282,7 +8331,7 @@ const otherDeductionsRefresh = (() => {
     window.scheduleCalculateAll?.('deduction-table-edit');
     const el = statusEl();
     if (el) {
-      el.textContent = 'Saved locally';
+      el.textContent = 'Saved to cloud';
       el.classList.remove('error');
       el.classList.add('saved');
     }
@@ -10310,7 +10359,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // Load existing history from localStorage or default to an empty array
   let payrollHistory;
   try {
-    payrollHistory = JSON.parse(localStorage.getItem(PAYROLL_HIST_KEY)) || [];
+    payrollHistory = (window.cacheGet ? window.cacheGet(PAYROLL_HIST_KEY, []) : JSON.parse(localStorage.getItem(PAYROLL_HIST_KEY) || '[]'));
     if (!Array.isArray(payrollHistory)) payrollHistory = [];
   } catch (err) {
     payrollHistory = [];
@@ -10516,7 +10565,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function loadLockMap() {
     try {
-      const raw = localStorage.getItem(PAYROLL_LOCKS_KEY);
+      const raw = JSON.stringify(window.cacheGet ? window.cacheGet(PAYROLL_LOCKS_KEY, null) : JSON.parse(localStorage.getItem(PAYROLL_LOCKS_KEY) || 'null'));
       if (!raw) return { __meta: { lastUpdatedAt: 0 } };
       const parsed = JSON.parse(raw);
       if (!parsed || typeof parsed !== 'object') return { __meta: { lastUpdatedAt: 0 } };
@@ -10535,7 +10584,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!payrollLocks || typeof payrollLocks !== 'object') payrollLocks = { __meta: {} };
       if (!payrollLocks.__meta) payrollLocks.__meta = {};
       if (changed) payrollLocks.__meta.lastUpdatedAt = Date.now();
-      localStorage.setItem(PAYROLL_LOCKS_KEY, JSON.stringify(payrollLocks));
+      persistCriticalBusinessKeySoon(PAYROLL_LOCKS_KEY, payrollLocks);
     } catch (err) {
       console.warn('Unable to persist payroll lock state', err);
     }
@@ -11988,35 +12037,12 @@ document.addEventListener('DOMContentLoaded', () => {
   window.showSyncFailedBanner = showSyncFailedBanner;
 
   async function persistKV(key, value) {
-    if (typeof window.writeKV === 'function') {
-      try {
-        const ok = await window.writeKV(key, value);
-        if (!ok) throw new Error('writeKV returned false');
-        return true;
-      } catch (error) {
-        console.warn('Payroll History kv_store sync failed', { key, error });
-        showSyncFailedBanner('Sync failed');
-        return false;
-      }
-    }
-
-    if (window.store && typeof window.store.setJSON === 'function') {
-      try {
-        const ok = window.store.setJSON(key, value);
-        if (!ok) throw new Error('store.setJSON returned false');
-        return true;
-      } catch (error) {
-        console.warn('Payroll History store sync failed', { key, error });
-        showSyncFailedBanner('Sync failed');
-        return false;
-      }
-    }
-
     try {
-      localStorage.setItem(key, JSON.stringify(value));
+      const ok = await persistCriticalBusinessKey(key, value);
+      if (!ok) throw new Error('critical writer returned false');
       return true;
     } catch (error) {
-      console.warn('Payroll History local save failed', { key, error });
+      console.warn('Payroll History sync failed', { key, error });
       showSyncFailedBanner('Sync failed');
       return false;
     }
@@ -16444,10 +16470,15 @@ const DEFAULT_SCHEDULE = {
 let storedRecords = (typeof window !== 'undefined' && Array.isArray(window.storedRecords))
   ? window.storedRecords
   : [];
-let storedEmployees = (window.cacheGet ? window.cacheGet(LS_EMPLOYEES, {}) : JSON.parse(localStorage.getItem(LS_EMPLOYEES) || '{}'));
-let storedSchedules = (window.cacheGet ? window.cacheGet(LS_SCHEDULES, null) : JSON.parse(localStorage.getItem(LS_SCHEDULES) || 'null'));
+let storedEmployees = normalizeObjectStore(window.cacheGet ? window.cacheGet(LS_EMPLOYEES, {}) : JSON.parse(localStorage.getItem(LS_EMPLOYEES) || '{}'));
+let storedSchedules = normalizeObjectStore(window.cacheGet ? window.cacheGet(LS_SCHEDULES, {}) : JSON.parse(localStorage.getItem(LS_SCHEDULES) || '{}'));
 let defaultScheduleId = (window.cacheGet ? window.cacheGet(LS_SCHEDULES_DEFAULT, null) : localStorage.getItem(LS_SCHEDULES_DEFAULT) || null);
-let storedProjects = (window.cacheGet ? window.cacheGet(LS_PROJECTS, {}) : JSON.parse(localStorage.getItem(LS_PROJECTS) || '{}'));
+let storedProjects = normalizeObjectStore(window.cacheGet ? window.cacheGet(LS_PROJECTS, {}) : JSON.parse(localStorage.getItem(LS_PROJECTS) || '{}'));
+
+function normalizeObjectStore(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return value;
+}
 
 function safeParseStorageJSON(key, fallbackValue) {
   try {
@@ -16464,9 +16495,9 @@ function refreshCoreStoresFromStorage() {
   overridesProjects = safeParseStorageJSON(LS_OVERRIDES_PROJECTS, {});
   splits = safeParseStorageJSON(LS_SPLITS, {});
   dtrOverrides = safeParseStorageJSON(LS_DTR_OVERRIDES, {});
-  storedEmployees = safeParseStorageJSON(LS_EMPLOYEES, {});
-  storedSchedules = safeParseStorageJSON(LS_SCHEDULES, null);
-  storedProjects = safeParseStorageJSON(LS_PROJECTS, {});
+  storedEmployees = normalizeObjectStore(safeParseStorageJSON(LS_EMPLOYEES, {}));
+  storedSchedules = normalizeObjectStore(safeParseStorageJSON(LS_SCHEDULES, {}));
+  storedProjects = normalizeObjectStore(safeParseStorageJSON(LS_PROJECTS, {}));
   payrollRates = safeParseStorageJSON(LS_RATES, {});
   regHours = safeParseStorageJSON(LS_REG_HRS, {});
   otHours = safeParseStorageJSON(LS_OT_HRS, {});
@@ -16543,8 +16574,8 @@ function ensureSchedules(){
   }
 }
 function saveSchedulesToLS(){
-  if (window.sharedSet) { window.sharedSet(LS_SCHEDULES, storedSchedules); window.sharedSet(LS_SCHEDULES_DEFAULT, defaultScheduleId); }
-  else { localStorage.setItem(LS_SCHEDULES, JSON.stringify(storedSchedules)); localStorage.setItem(LS_SCHEDULES_DEFAULT, defaultScheduleId); }
+  persistCriticalBusinessKeySoon(LS_SCHEDULES, storedSchedules);
+  persistCriticalBusinessKeySoon(LS_SCHEDULES_DEFAULT, defaultScheduleId);
 }
 
 const LS_ACTIVE_MAIN_TAB = 'bp_active_main_tab';
@@ -16784,6 +16815,7 @@ const scheduleSelect = document.getElementById('scheduleSelect');
 const scheduleNameInput = document.getElementById('scheduleName');
 
 function renderScheduleSelector(){
+  if(!storedSchedules || typeof storedSchedules !== 'object' || Array.isArray(storedSchedules)) storedSchedules = {};
   scheduleSelect.innerHTML = '';
   Object.keys(storedSchedules).forEach(id=>{
     const opt = document.createElement('option');
@@ -16886,9 +16918,10 @@ function resetRanges(){
 document.getElementById('saveRangesBtn').addEventListener('click', saveRangesFromUI);
 document.getElementById('resetRangesBtn').addEventListener('click', resetRanges);
 
-function saveEmployeesToLS(){ if (window.sharedSet) window.sharedSet(LS_EMPLOYEES, storedEmployees); else localStorage.setItem(LS_EMPLOYEES, JSON.stringify(storedEmployees)); }
+function saveEmployeesToLS(){ persistCriticalBusinessKeySoon(LS_EMPLOYEES, storedEmployees); }
 function renderEmpScheduleDropdowns(){
   const sel = document.getElementById('empScheduleSelect'); if(!sel) return;
+  if(!storedSchedules || typeof storedSchedules !== 'object' || Array.isArray(storedSchedules)) storedSchedules = {};
   sel.innerHTML = '';
   Object.keys(storedSchedules).forEach(id=>{
     const o=document.createElement('option'); o.value=id;
@@ -16898,6 +16931,7 @@ function renderEmpScheduleDropdowns(){
   if(defaultScheduleId && storedSchedules[defaultScheduleId]) sel.value = defaultScheduleId;
 }
 function renderEmpScheduleDropdownsInTable(){
+  if(!storedSchedules || typeof storedSchedules !== 'object' || Array.isArray(storedSchedules)) storedSchedules = {};
   document.querySelectorAll('.emp-sel-schedule').forEach(sel=>{
     const id = sel.dataset.id;
     sel.innerHTML = '';
@@ -16946,7 +16980,7 @@ function syncProjectsKVAfterLocalSave(forceCloudWrite){
 }
 
 function saveProjectsToLS(options = {}){
-  if (window.sharedSet) window.sharedSet(LS_PROJECTS, storedProjects); else localStorage.setItem(LS_PROJECTS, JSON.stringify(storedProjects));
+  persistCriticalBusinessKeySoon(LS_PROJECTS, storedProjects);
   syncProjectsKVAfterLocalSave(!!(options && options.userEdited));
   if(!(options && options.skipRender)){
     renderProjects();
@@ -17214,7 +17248,7 @@ function renderEmployees(){
     const id = e.target.dataset.id;
     const val = parseFloat(e.target.value) || 0;
     storedEmployees[id].hourlyRate = val; saveEmployeesToLS();
-    try { payrollRates[id] = val; if (window.sharedSet) window.sharedSet(LS_RATES, payrollRates); else localStorage.setItem(LS_RATES, JSON.stringify(payrollRates)); } catch(err) {}
+    try { payrollRates[id] = val; persistCriticalBusinessKeySoon(LS_RATES, payrollRates); } catch(err) {}
     try { if (typeof renderTable === 'function') renderTable(); } catch (err) { console.warn('renderTable failed', err); }
     window.scheduleRenderResults?.('employee-rate-change');
     window.scheduleCalculateAll?.('employee-rate-change');
@@ -17455,7 +17489,7 @@ function resolveDtrPersistFn(){
 async function persistDtrSnapshotFallback(){
   const snapshot = Array.isArray(storedRecords) ? storedRecords.slice() : [];
   try { window.storedRecords = snapshot; } catch (_) {}
-  try { localStorage.setItem(LS_RECORDS, JSON.stringify(snapshot)); } catch (_) {}
+  try { persistCriticalBusinessKeySoon(LS_RECORDS, snapshot); } catch (_) {}
   if (typeof saveDtrToCloud === 'function') {
     await saveDtrToCloud(snapshot);
   }
@@ -18382,7 +18416,7 @@ function __setDtrRecordsAndRender(records, reason='dtr-load'){
   next.sort((a,b)=> String(a.date||'').localeCompare(String(b.date||'')) || String(a.time||'').localeCompare(String(b.time||'')) || String(a.empId||'').localeCompare(String(b.empId||'')));
   try { storedRecords = next; } catch(_) {}
   try { window.storedRecords = next; } catch(_) {}
-  try { if (window.sharedSet) window.sharedSet(LS_RECORDS, next); else localStorage.setItem(LS_RECORDS, JSON.stringify(next)); } catch(_) {}
+  try { persistCriticalBusinessKeySoon(LS_RECORDS, next); } catch(_) {}
   try { if (typeof window.scheduleRenderResults === 'function') window.scheduleRenderResults(reason); else if (typeof window.renderResults === 'function') window.renderResults(); } catch(_) {}
 }
 
@@ -18880,7 +18914,7 @@ function calculatePayrollFromRecords(){
   });
   // Persist rates
   try {
-    if (window.sharedSet) window.sharedSet(LS_RATES, payrollRates); else localStorage.setItem(LS_RATES, JSON.stringify(payrollRates));
+    persistCriticalBusinessKeySoon(LS_RATES, payrollRates);
   } catch (err) {}
   // Rebuild the payroll table with the newly computed hours
   try {
@@ -21354,7 +21388,7 @@ function loadSaved(){
 
   function loadHistory() {
     try {
-      const hist = JSON.parse(localStorage.getItem(PAYROLL_HIST_KEY)) || [];
+      const hist = (window.cacheGet ? window.cacheGet(PAYROLL_HIST_KEY, []) : JSON.parse(localStorage.getItem(PAYROLL_HIST_KEY) || '[]'));
       return Array.isArray(hist) ? hist : [];
     } catch (e) {
       return [];
@@ -21552,7 +21586,7 @@ function updateWeekInputs(snap) {
           } catch (_) {}
         });
       } else {
-        localStorage.setItem(PAYROLL_HIST_KEY, JSON.stringify(localHist));
+        persistCriticalBusinessKeySoon(PAYROLL_HIST_KEY, localHist);
       }
     }
     // Refresh UI pieces
@@ -21823,7 +21857,7 @@ async function saveDtrToCloudLegacyBlob(records) {
       try {
         storedRecords = remoteRecs;
         window.storedRecords = remoteRecs;
-        if (window.sharedSet) window.sharedSet(LS_RECORDS, remoteRecs); else localStorage.setItem(LS_RECORDS, JSON.stringify(remoteRecs));
+        persistCriticalBusinessKeySoon(LS_RECORDS, remoteRecs);
       } catch(e) {}
       return;
     }
@@ -21888,7 +21922,7 @@ async function saveDtrToCloudLegacyBlob(records) {
     try {
       storedRecords = mergedRecs;
       window.storedRecords = mergedRecs;
-      if (window.sharedSet) window.sharedSet(LS_RECORDS, mergedRecs); else localStorage.setItem(LS_RECORDS, JSON.stringify(mergedRecs));
+      persistCriticalBusinessKeySoon(LS_RECORDS, mergedRecs);
     } catch(e) {}
 
     saveJson(LS_TOMBS, mergedTombs);
@@ -23044,9 +23078,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     const snapshot = Array.isArray(storedRecords) ? storedRecords.slice() : [];
     try { window.storedRecords = snapshot; } catch(_) {}
     try {
-      if (window.sharedSet) await window.sharedSet(LS_RECORDS, snapshot);
-      else if (window.cacheSet) window.cacheSet(LS_RECORDS, snapshot);
-      else localStorage.setItem(LS_RECORDS, JSON.stringify(snapshot));
+      await persistCriticalBusinessKey(LS_RECORDS, snapshot);
     } catch(e){
       console.warn('Failed to persist DTR records locally', e);
     }

--- a/src/legacy/backupRestore.js
+++ b/src/legacy/backupRestore.js
@@ -20,6 +20,34 @@
     function clearLog(){ try{ logEl.innerHTML=''; logEl.style.display='none'; }catch(e){} }
     function tryJSON(v){ try{ return JSON.parse(v); }catch{ return v; } }
 
+    const FALLBACK_CRITICAL_KEYS = new Set([
+      'att_employees_v2',
+      'att_projects_v1',
+      'att_schedules_v2',
+      'att_schedules_default',
+      'att_records_v2',
+      'payroll_loan_tracker',
+      'payroll_loan_sss',
+      'payroll_loan_pagibig',
+      'payroll_vale',
+      'payroll_vale_wed',
+      'payroll_contrib_flags',
+      'payroll_lock_state',
+      'payroll_rates',
+      'payroll_hist',
+      'payroll_other_deductions_details',
+      'payroll_other_deductions_total',
+      'payroll_additional_income_details',
+      'payroll_additional_income_total',
+    ]);
+
+    function getCriticalKeySet(){
+      const shared = window.__PAYROLL_CRITICAL_KEYS;
+      if (shared && typeof shared.has === 'function') return shared;
+      return FALLBACK_CRITICAL_KEYS;
+    }
+
+
     async function fetchKVAll(){
       const supa = getSupa();
       if(!supa) return { rows:[], error:'No Supabase client' };
@@ -117,8 +145,29 @@
 
     // Cloud listing removed
 
-    function applyLocalStorage(ls){
-      try{ Object.keys(ls||{}).forEach(k=>{ try{ localStorage.setItem(k, JSON.stringify(ls[k])); }catch(_){} }); }catch(e){}
+    async function applyLocalStorage(ls){
+      const criticalKeys = getCriticalKeySet();
+      try {
+        for (const k of Object.keys(ls || {})) {
+          const value = ls[k];
+          if (criticalKeys.has(k)) {
+            try {
+              if (typeof window.writeKV === 'function') {
+                await window.writeKV(k, value);
+              } else if (typeof window.sharedSet === 'function') {
+                await window.sharedSet(k, value);
+              } else {
+                log('Skipped critical key restore without cloud writer: ' + k);
+              }
+            } catch (_) {
+              log('Failed critical key restore via cloud writer: ' + k);
+            }
+            continue;
+          }
+
+          try { localStorage.setItem(k, JSON.stringify(value)); } catch (_) {}
+        }
+      } catch (e) {}
     }
     async function applyKV(kv){
       const supa = getSupa();
@@ -136,7 +185,7 @@
       try{
         await supa.from(DTR_TABLE).upsert({ id:'records', data: Array.isArray(rows)?rows:[] }, { onConflict:'id' });
         window.storedRecords = Array.isArray(rows)?rows:[];
-        try{ if (window.sharedSet) window.sharedSet('att_records_v2', window.storedRecords); else localStorage.setItem('att_records_v2', JSON.stringify(window.storedRecords)); }catch(_){ }
+        try{ if (typeof window.writeKV === 'function') window.writeKV('att_records_v2', window.storedRecords); else if (window.sharedSet) window.sharedSet('att_records_v2', window.storedRecords); }catch(_){ }
       }catch(e){ log('DTR upsert error: ' + String(e)); }
     }
 
@@ -164,7 +213,7 @@
       try{
         const text = await f.text(); const bundle = JSON.parse(text||'{}');
         if(!bundle || bundle.schema !== 'payrollhub.full.v1') throw new Error('Invalid bundle schema');
-        applyLocalStorage(bundle.localStorage || {}); log('Applied localStorage');
+        await applyLocalStorage(bundle.localStorage || {}); log('Applied localStorage (critical keys routed to cloud writers)');
         await applyKV(bundle.kv || []); log('Applied KV table');
         await applyDTR(bundle.dtr || []); log('Applied DTR rows');
         setStatus('Restore complete', false); alert('Restore complete.');

--- a/src/legacy/kvSyncAdapter.js
+++ b/src/legacy/kvSyncAdapter.js
@@ -5,6 +5,28 @@ const SUPABASE_KEY = window.SUPABASE_KEY || "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ
 const TABLE = "kv_store";
 const SHARED_KEYS = ["att_employees_v2","att_schedules_v2","att_schedules_default","att_projects_v1","att_records_v2","att_overrides_hours_v1","dtr_overrides_v1","payroll_rates","payroll_ot_multiplier","payroll_week_start","payroll_week_end","settings_payroll","payroll_deduction_divisor","payroll_sss_table","payroll_pagibig_table","payroll_philhealth_table","payroll_pagibig_rate","payroll_philhealth_rate","payroll_loan_sss","payroll_loan_pagibig","payroll_loan_tracker","payroll_vale","payroll_vale_wed","payroll_hist","payroll_other_deductions_details","payroll_other_deductions_total","payroll_additional_income_details","payroll_additional_income_total","payroll_adjustment_hours","payroll_bantay","payroll_bantay_proj","payroll_contrib_flags","payroll_lock_state","incomeTypeOptions","deductionTypeOptions","payroll_print_orientation"];
 const SHARED_KEY_SET = new Set(SHARED_KEYS);
+const CRITICAL_REMOTE_ONLY_KEYS = new Set([
+  'att_employees_v2',
+  'att_projects_v1',
+  'att_schedules_v2',
+  'att_schedules_default',
+  'att_records_v2',
+  'payroll_loan_tracker',
+  'payroll_loan_sss',
+  'payroll_loan_pagibig',
+  'payroll_vale',
+  'payroll_vale_wed',
+  'payroll_contrib_flags',
+  'payroll_lock_state',
+  'payroll_rates',
+  'payroll_hist',
+  'payroll_other_deductions_details',
+  'payroll_other_deductions_total',
+  'payroll_additional_income_details',
+  'payroll_additional_income_total',
+]);
+window.__PAYROLL_CRITICAL_KEYS = window.__PAYROLL_CRITICAL_KEYS || new Set(CRITICAL_REMOTE_ONLY_KEYS);
+const CRITICAL_MIGRATION_ACK_KEY = '__payroll_critical_ls_seed_ack_v1';
 const PENDING_KEY = '__shared_pending_writes_v1';
 const META_KEY = '__shared_meta_v1';
 const DEVICE_KEY = '__device_id';
@@ -17,7 +39,7 @@ window.SUPABASE_TABLE = TABLE;
 window.SHARED_KEYS = SHARED_KEYS;
 window.SHARED_KEY_SET = SHARED_KEY_SET;
 window.__supabase_ready = true;
-window.__sharedSyncState = window.__sharedSyncState || { hydrated:false, offline:false, lastSyncAt:0, conflict:false };
+window.__sharedSyncState = window.__sharedSyncState || { hydrated:false, hydrateAttempted:false, hydrateSucceeded:false, offline:false, lastSyncAt:0, conflict:false };
 try { console.warn('[boot] supabase ready'); window.dispatchEvent(new Event('supabase-ready')); } catch (_) {}
 
 const __origGetItem = window.localStorage.getItem.bind(window.localStorage);
@@ -25,6 +47,9 @@ const __origSetItem = window.localStorage.setItem.bind(window.localStorage);
 const __origRemoveItem = window.localStorage.removeItem.bind(window.localStorage);
 
 function cacheGet(key, fallback = null) {
+  if (CRITICAL_REMOTE_ONLY_KEYS.has(key) && !canUseCriticalLocalFallback()) {
+    return fallback;
+  }
   try {
     const raw = __origGetItem ? __origGetItem(key) : localStorage.getItem(key);
     if (raw == null) return fallback;
@@ -41,6 +66,19 @@ function cacheSet(key, value) {
 }
 window.cacheGet = cacheGet;
 window.cacheSet = cacheSet;
+
+function canUseCriticalLocalFallback() {
+  const state = window.__sharedSyncState || {};
+  const allowFallback = window.__PAYROLL_ALLOW_CRITICAL_LS_FALLBACK !== false;
+  if (!allowFallback) return false;
+  // Hybrid mode safety: before hydrate completes, keep local/cache fallback available
+  // so business stores do not boot as empty when cloud is late/offline.
+  if (!state.hydrated) return true;
+  if (state.hydrateSucceeded) return true;
+  const allowDegradedFallback = window.__PAYROLL_ALLOW_CRITICAL_LS_DEGRADED_READ !== false;
+  return !!state.offline && allowDegradedFallback;
+}
+
 
 function getDeviceId() {
   let id = localStorage.getItem(DEVICE_KEY) || '';
@@ -99,6 +137,36 @@ async function sharedGet(key, fallback = null) {
   } catch (_) {
     return cacheGet(key, fallback);
   }
+}
+
+function clearCriticalLegacyLocalCache() {
+  try {
+    for (const key of CRITICAL_REMOTE_ONLY_KEYS) {
+      __origRemoveItem(key);
+    }
+  } catch (_) {}
+}
+
+async function maybeSeedCriticalKeysFromLegacyLocal() {
+  const shouldSeed = window.__PAYROLL_ENABLE_CRITICAL_LS_SEED === true;
+  if (!shouldSeed) return;
+  if (cacheGet(CRITICAL_MIGRATION_ACK_KEY, false)) return;
+
+  for (const key of CRITICAL_REMOTE_ONLY_KEYS) {
+    try {
+      const cloud = await kvReadCloud(key);
+      if (cloud && cloud.value !== undefined) continue;
+      const raw = __origGetItem(key);
+      if (!raw) continue;
+      let parsed = raw;
+      try { parsed = JSON.parse(raw); } catch (_) {}
+      await sharedSet(key, parsed);
+    } catch (error) {
+      console.warn('[payroll:migration] failed to seed critical key', key, error?.message || error);
+    }
+  }
+
+  cacheSet(CRITICAL_MIGRATION_ACK_KEY, true);
 }
 
 async function sharedSet(key, value) {
@@ -206,6 +274,7 @@ async function flushPending() {
 }
 
 async function sharedHydrateAll() {
+  window.__sharedSyncState.hydrateAttempted = true;
   try {
     const { data, error } = await supabase.from(TABLE).select('key,value,updated_at').in('key', SHARED_KEYS);
     if (error) throw error;
@@ -225,7 +294,10 @@ async function sharedHydrateAll() {
     }
     await flushPending();
     window.__sharedSyncState.offline = false;
+    window.__sharedSyncState.hydrateSucceeded = true;
   } catch (e) {
+    window.__sharedSyncState.hydrateSucceeded = false;
+    window.__sharedSyncState.offline = true;
     console.warn('sharedHydrateAll offline/failed:', e?.message || e);
   } finally {
     window.__sharedSyncState.hydrated = true;
@@ -276,6 +348,12 @@ kvChannel.subscribe();
 window.__sharedKvChannel = kvChannel;
 
 window.addEventListener('online', () => { flushPending().catch(() => {}); });
+
+maybeSeedCriticalKeysFromLegacyLocal().catch(() => {});
+sharedHydrateAll().then(() => {
+  const shouldClear = window.__PAYROLL_CLEAR_CRITICAL_LOCAL_AFTER_HYDRATE === true;
+  if (window.__sharedSyncState.hydrateSucceeded && shouldClear) clearCriticalLegacyLocalCache();
+}).catch(() => {});
 
 if (!window.__sharedStorageHooked) {
   window.__sharedStorageHooked = true;

--- a/src/main.js
+++ b/src/main.js
@@ -8,102 +8,87 @@ let cleanupUi = null;
 let cleanupRealtime = null;
 let bootstrapped = false;
 
-const CRITICAL_LOCAL_KEYS = new Set([
-  'att_employees_v2',
-  'att_projects_v1',
-  'att_schedules_v2',
-  'att_schedules_default',
-  'att_records_v2',
-  'payroll_loan_tracker',
-  'payroll_loan_sss',
-  'payroll_loan_pagibig',
-  'payroll_vale',
-  'payroll_vale_wed',
-  'payroll_contrib_flags',
-  'payroll_lock_state',
-  'payroll_rates',
-  'payroll_hist',
-  'payroll_other_deductions_details',
-  'payroll_other_deductions_total',
-  'payroll_additional_income_details',
-  'payroll_additional_income_total',
-]);
+function installDevLocalStorageDetector() {
+  if (window.__payrollLocalDetectorInstalled) return;
+  window.__payrollLocalDetectorInstalled = true;
 
-function deprecateCriticalLocalAuthority() {
-  if (window.__payrollLocalAuthorityDeprecated) return;
-  window.__payrollLocalAuthorityDeprecated = true;
-
-  const warnedKeys = new Set();
   const debugDeprecation = !!window.__PAYROLL_DEBUG_DEPRECATION;
-  const requestedStrictDeprecation = !!window.__PAYROLL_STRICT_LOCAL_DEPRECATION;
-  const isLocalDev = ['localhost', '127.0.0.1'].includes(window.location?.hostname || '');
-  const strictDeprecation = requestedStrictDeprecation && isLocalDev;
-  if (requestedStrictDeprecation && !isLocalDev) {
-    console.warn('[payroll:deprecation] strict local authority blocking is ignored outside local dev hosts');
-  }
-  const warnOnce = (kind, key) => {
-    if (!debugDeprecation) return;
-    const marker = `${kind}:${key}`;
-    if (warnedKeys.has(marker)) return;
-    warnedKeys.add(marker);
-    console.warn(`[payroll:deprecation] ${kind} for critical key`, key);
+  const strict = !!window.__PAYROLL_STRICT_LOCAL_DEPRECATION;
+  if (!debugDeprecation && !strict) return;
+
+  const CRITICAL_KEYS = new Set([
+    'att_employees_v2',
+    'att_projects_v1',
+    'att_schedules_v2',
+    'att_schedules_default',
+    'att_records_v2',
+    'payroll_loan_tracker',
+    'payroll_loan_sss',
+    'payroll_loan_pagibig',
+    'payroll_vale',
+    'payroll_vale_wed',
+    'payroll_contrib_flags',
+    'payroll_lock_state',
+    'payroll_rates',
+    'payroll_hist',
+    'payroll_other_deductions_details',
+    'payroll_other_deductions_total',
+    'payroll_additional_income_details',
+    'payroll_additional_income_total',
+  ]);
+
+  const report = (kind, key) => {
+    if (!CRITICAL_KEYS.has(key)) return;
+    const msg = `[payroll:diagnostic] ${kind} critical key: ${key}`;
+    if (debugDeprecation) console.warn(msg);
+    if (strict) throw new Error(msg);
   };
 
-
-  const originalReadKv = window.readKV;
-  if (typeof originalReadKv === 'function') {
-    window.readKV = async (key, fallback) => {
-      if (CRITICAL_LOCAL_KEYS.has(key)) {
-        warnOnce('KV read observed (legacy fallback candidate)', key);
-      }
-      return originalReadKv(key, fallback);
-    };
-  }
-
-  const originalWriteKv = window.writeKV;
-  if (typeof originalWriteKv === 'function') {
-    window.writeKV = async (key, value) => {
-      if (CRITICAL_LOCAL_KEYS.has(key)) {
-        warnOnce('KV write observed (allowed for compatibility)', key);
-        if (strictDeprecation) {
-          throw new Error(`[payroll:deprecation] blocked critical KV write for ${key}`);
-        }
-      }
-      return originalWriteKv(key, value);
-    };
-  }
-
   try {
-
     const originalGetItem = window.localStorage.getItem.bind(window.localStorage);
+    const originalSetItem = window.localStorage.setItem.bind(window.localStorage);
+    const originalRemoveItem = window.localStorage.removeItem.bind(window.localStorage);
+
     window.localStorage.getItem = (key) => {
-      if (CRITICAL_LOCAL_KEYS.has(key)) {
-        warnOnce('localStorage read observed (legacy fallback candidate)', key);
-      }
+      report('localStorage.getItem', key);
       return originalGetItem(key);
     };
 
-    const originalSetItem = window.localStorage.setItem.bind(window.localStorage);
     window.localStorage.setItem = (key, value) => {
-      if (CRITICAL_LOCAL_KEYS.has(key)) {
-        warnOnce('localStorage write observed', key);
-        if (strictDeprecation) {
-          throw new Error(`[payroll:deprecation] blocked critical localStorage write for ${key}`);
-        }
-      }
+      report('localStorage.setItem', key);
       return originalSetItem(key, value);
     };
+
+    window.localStorage.removeItem = (key) => {
+      report('localStorage.removeItem', key);
+      return originalRemoveItem(key);
+    };
+
+    if (typeof window.readKV === 'function') {
+      const originalReadKv = window.readKV;
+      window.readKV = async (key, fallback) => {
+        report('readKV', key);
+        return originalReadKv(key, fallback);
+      };
+    }
+
+    if (typeof window.writeKV === 'function') {
+      const originalWriteKv = window.writeKV;
+      window.writeKV = async (key, value) => {
+        report('writeKV', key);
+        return originalWriteKv(key, value);
+      };
+    }
   } catch (error) {
-    console.warn('localStorage interception failed', error);
+    console.warn('localStorage diagnostic hook failed', error);
   }
 }
-
 
 async function bootstrapPayrollApp() {
   if (bootstrapped) return;
   bootstrapped = true;
 
-  deprecateCriticalLocalAuthority();
+  installDevLocalStorageDetector();
 
   const root = document.getElementById('panelPayroll') || document.body;
   cleanupUi = mountPayrollController(root);
@@ -165,9 +150,9 @@ async function bootstrapPayrollApp() {
 
 
 try {
-  deprecateCriticalLocalAuthority();
+  installDevLocalStorageDetector();
 } catch (error) {
-  console.warn('initial localStorage deprecation hook failed', error);
+  console.warn('initial localStorage diagnostic hook failed', error);
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
### Motivation
- Move authoritative storage of critical payroll datasets from localStorage to the cloud-backed KV path to avoid accidental local overwrites and enable cross-device sync.
- Provide safer persistence primitives with explicit handling for critical keys, plus a migration path from legacy localStorage blobs.
- Surface developer diagnostics to detect/optionally block accidental local reads/writes of critical keys during development.

### Description
- Introduces `CRITICAL_PAYROLL_KEYS`, `persistCriticalBusinessKey`, and `persistCriticalBusinessKeySoon` helpers and replaces many direct `localStorage`/`sharedSet`/`cacheSet` writes with calls to these helpers for critical keys (employees, projects, schedules, records, loan tracker, rates, history, etc.).
- Enhances KV sync adapter to treat a set of keys as remote-first (`CRITICAL_REMOTE_ONLY_KEYS`), add hybrid cache semantics (`canUseCriticalLocalFallback`), seed cloud KV from legacy localStorage (`maybeSeedCriticalKeysFromLegacyLocal`), and clear legacy local cache after successful hydrate when configured.
- Updates backup/restore logic to route critical keys to cloud writers during a restore and to skip/emit logs if writers are unavailable, and adjusts other modules to normalize object stores and safe-parse cached values.
- Adds a lightweight diagnostic/local-storage interception in `main.js` (`installDevLocalStorageDetector`) to warn or throw on critical key reads/writes when debug/strict flags are set, and updates UI copy to reflect cloud-saved state (e.g. "Saved to cloud").

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b120850e9883289b8ccacf8ff29036)