### PR TITLE
Enable legacy DTR realtime subscriptions to restore manual DTR cross-device sync

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -274,7 +274,11 @@ async function bootstrapPayrollApp() {
 
     try {
       initRealtimeManager();
-      window.__DISABLE_LEGACY_DTR_SUBSCRIPTIONS = true;
+      // Keep legacy DTR subscriptions enabled for now because the current DTR
+      // UI still renders from `window.storedRecords`. Disabling legacy
+      // subscriptions prevents manual DTR updates from propagating across
+      // devices in real time.
+      window.__DISABLE_LEGACY_DTR_SUBSCRIPTIONS = false;
       if (window.__ENABLE_DTR_LIVE_REALTIME == null) window.__ENABLE_DTR_LIVE_REALTIME = false;
       subscribePayrollCore({ periodId: currentPeriodId });
       window.payrollRealtimeManager = {


### PR DESCRIPTION
### Motivation
- The DTR UI still renders from `window.storedRecords`, and disabling the legacy realtime subscriptions prevented manual DTR entries from propagating to other devices in real time.

### Description
- Re-enable legacy DTR subscriptions by setting `window.__DISABLE_LEGACY_DTR_SUBSCRIPTIONS = false` in `src/main.js` and add an inline comment explaining the compatibility requirement.

### Testing
- Ran `node --check src/main.js` to validate syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c61a019d488328b8ca48856608ba09)