### PR TITLE
Inline legacy scripts and add Supabase-backed shared KV sync, perf tweaks, backup/restore, audit and realtime payroll modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -628,12 +628,430 @@
   <link rel="modulepreload" href="https://esm.sh/@supabase/supabase-js@2?bundle" crossorigin>
 
   
-<script id="bpSafeDomHelpers" src="./src/legacy/bpSafeDomHelpers.js"></script>
+<script id="bpSafeDomHelpers">
+(function(){
+  if (window.__bpSafeDom) return;
+  window.__bpSafeDom = {
+    byId: function(id){ return document.getElementById(id); },
+    on: function(el, ev, fn, opts){ if (!el || !el.addEventListener) return false; el.addEventListener(ev, fn, opts); return true; },
+    val: function(el){ return el && typeof el.value !== 'undefined' ? el.value : ''; }
+  };
+})();
 
-<script type="module" src="./src/legacy/perfTweaks.js"></script>
+</script>
+
+<script type="module">
+    // Non-invasive performance tweaks: lazy-load offscreen media, async decode images.
+    const onReady = (cb) => {
+      if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', cb, { once: true });
+      else cb();
+    };
+    onReady(() => {
+      try {
+        const vh = window.innerHeight || document.documentElement.clientHeight || 800;
+        document.querySelectorAll('img').forEach(img => {
+          try { if (!img.hasAttribute('decoding')) img.setAttribute('decoding', 'async'); } catch {}
+          if (!img.hasAttribute('loading')) {
+            const rect = img.getBoundingClientRect();
+            if (rect && rect.top > vh) { try { img.setAttribute('loading', 'lazy'); } catch {} }
+          }
+        });
+        document.querySelectorAll('iframe').forEach(el => {
+          if (!el.hasAttribute('loading')) { try { el.setAttribute('loading', 'lazy'); } catch {} }
+        });
+      } catch { /* no-op */ }
+    });
+
+</script>
 
 <!-- === Supabase KV Sync Adapter (single unified shared storage) === -->
-<script type="module" src="./src/legacy/kvSyncAdapter.js"></script>
+<script type="module">
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2?bundle";
+
+const SUPABASE_URL = window.SUPABASE_URL || "https://qzkzugzfpegozpiqutdv.supabase.co";
+const SUPABASE_KEY = window.SUPABASE_KEY || "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InF6a3p1Z3pmcGVnb3pwaXF1dGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTU4MTc5MDMsImV4cCI6MjA3MTM5MzkwM30.mdFYuFjbRfsILWPkQQmVUCDR7dGqEo-mdPZ6iwolvGk";
+const TABLE = "kv_store";
+const SHARED_KEYS = ["att_employees_v2","att_schedules_v2","att_schedules_default","att_projects_v1","att_records_v2","att_overrides_hours_v1","dtr_overrides_v1","payroll_rates","payroll_ot_multiplier","payroll_week_start","payroll_week_end","settings_payroll","payroll_deduction_divisor","payroll_sss_table","payroll_pagibig_table","payroll_philhealth_table","payroll_pagibig_rate","payroll_philhealth_rate","payroll_loan_sss","payroll_loan_pagibig","payroll_loan_tracker","payroll_vale","payroll_vale_wed","payroll_hist","payroll_other_deductions_details","payroll_other_deductions_total","payroll_additional_income_details","payroll_additional_income_total","payroll_adjustment_hours","payroll_bantay","payroll_bantay_proj","payroll_contrib_flags","payroll_lock_state","incomeTypeOptions","deductionTypeOptions","payroll_print_orientation"];
+const SHARED_KEY_SET = new Set(SHARED_KEYS);
+const CRITICAL_BUSINESS_KEYS = new Set([
+  "att_employees_v2",
+  "att_projects_v1",
+  "att_schedules_v2",
+  "att_schedules_default",
+  "payroll_hist",
+  "payroll_lock_state",
+  "payroll_adjustment_hours",
+  "payroll_bantay",
+  "payroll_bantay_proj",
+  "payroll_rates",
+  "payroll_other_deductions_details",
+  "payroll_other_deductions_total",
+  "payroll_additional_income_details",
+  "payroll_additional_income_total",
+  "payroll_contrib_flags",
+  "payroll_loan_tracker"
+]);
+const OBJECT_STORE_KEYS = new Set(["att_employees_v2", "att_projects_v1", "att_schedules_v2"]);
+const PENDING_KEY = '__shared_pending_writes_v1';
+const META_KEY = '__shared_meta_v1';
+const DEVICE_KEY = '__device_id';
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false }
+});
+window.supabase = supabase;
+window.SUPABASE_TABLE = TABLE;
+window.SHARED_KEYS = SHARED_KEYS;
+window.SHARED_KEY_SET = SHARED_KEY_SET;
+window.__supabase_ready = true;
+window.__sharedSyncState = window.__sharedSyncState || { hydrated:false, offline:false, lastSyncAt:0, conflict:false };
+try { console.warn('[boot] supabase ready'); window.dispatchEvent(new Event('supabase-ready')); } catch (_) {}
+
+const __origGetItem = window.localStorage.getItem.bind(window.localStorage);
+const __origSetItem = window.localStorage.setItem.bind(window.localStorage);
+const __origRemoveItem = window.localStorage.removeItem.bind(window.localStorage);
+
+function cacheGet(key, fallback = null) {
+  try {
+    const raw = __origGetItem ? __origGetItem(key) : localStorage.getItem(key);
+    if (raw == null) return fallback;
+    try { return JSON.parse(raw); } catch (_) { return raw; }
+  } catch (_) {
+    return fallback;
+  }
+}
+function cacheSet(key, value) {
+  try {
+    if (value === undefined) { __origRemoveItem(key); return; }
+    __origSetItem(key, JSON.stringify(value));
+  } catch (_) {}
+}
+
+function normalizeObjectStore(value) {
+  if (value && typeof value === 'object' && !Array.isArray(value)) return value;
+  return {};
+}
+
+function hasMeaningfulData(value) {
+  if (value == null) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === 'object') return Object.keys(value).length > 0;
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value === 'boolean') return true;
+  return false;
+}
+
+function normalizeValueForKey(key, value) {
+  if (!OBJECT_STORE_KEYS.has(key)) return value;
+  return normalizeObjectStore(value);
+}
+
+function chooseCriticalValue(key, cloudValue, localValue) {
+  const normalizedCloud = normalizeValueForKey(key, cloudValue);
+  const normalizedLocal = normalizeValueForKey(key, localValue);
+  if (!CRITICAL_BUSINESS_KEYS.has(key)) {
+    return normalizedCloud;
+  }
+  if (hasMeaningfulData(normalizedCloud)) return normalizedCloud;
+  if (hasMeaningfulData(normalizedLocal)) {
+    console.warn('[shared-kv] preserve local critical data during hydrate', { key });
+    return normalizedLocal;
+  }
+  return normalizedCloud;
+}
+window.cacheGet = cacheGet;
+window.cacheSet = cacheSet;
+
+function getDeviceId() {
+  let id = localStorage.getItem(DEVICE_KEY) || '';
+  if (!id) {
+    id = (crypto?.randomUUID?.() || `dev_${Date.now()}_${Math.random().toString(36).slice(2)}`);
+    __origSetItem(DEVICE_KEY, id);
+  }
+  return id;
+}
+function wrapForStore(value) {
+  return { __data: value, __meta: { updatedAt: Date.now(), deviceId: getDeviceId() } };
+}
+function unwrapFromStore(value) {
+  if (value && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, '__deleted') && value.__deleted) return undefined;
+  if (value && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, '__data')) return value.__data;
+  return value;
+}
+function metaFromStore(value) {
+  if (value && typeof value === 'object' && value.__meta && typeof value.__meta === 'object') {
+    return { updatedAt: Number(value.__meta.updatedAt || 0), deviceId: String(value.__meta.deviceId || '') };
+  }
+  return { updatedAt: 0, deviceId: '' };
+}
+function loadMetaMap(){ const m = cacheGet(META_KEY, {}); return (m && typeof m === 'object' && !Array.isArray(m)) ? m : {}; }
+let metaMap = loadMetaMap();
+function saveMetaMap(){ cacheSet(META_KEY, metaMap); }
+function setMetaForKey(key, meta){ metaMap[key] = { updatedAt:Number(meta?.updatedAt||0), deviceId:String(meta?.deviceId||'') }; saveMetaMap(); }
+
+async function kvReadCloud(key) {
+  const { data, error } = await supabase.from(TABLE).select('value, updated_at').eq('key', key).maybeSingle();
+  if (error) throw error;
+  return data || null;
+}
+async function kvWriteCloud(key, wrapped) {
+  const { error } = await supabase.from(TABLE).upsert({ key, value: wrapped }, { onConflict: 'key' });
+  if (error) throw error;
+}
+async function kvDeleteCloud(key) {
+  const { error } = await supabase.from(TABLE).delete().eq('key', key);
+  if (error) throw error;
+}
+
+function getPending(){ const q = cacheGet(PENDING_KEY, {}); return (q && typeof q === 'object' && !Array.isArray(q)) ? q : {}; }
+function setPending(v){ cacheSet(PENDING_KEY, v || {}); }
+
+async function sharedGet(key, fallback = null) {
+  if (!SHARED_KEY_SET.has(key)) return cacheGet(key, fallback);
+  if (window.__sharedSyncState.hydrated) return cacheGet(key, fallback);
+  try {
+    const row = await kvReadCloud(key);
+    if (!row || row.value === undefined) return cacheGet(key, fallback);
+    const unwrapped = unwrapFromStore(row.value);
+    cacheSet(key, unwrapped);
+    setMetaForKey(key, metaFromStore(row.value));
+    return unwrapped === undefined ? fallback : unwrapped;
+  } catch (_) {
+    return cacheGet(key, fallback);
+  }
+}
+
+async function sharedSet(key, value) {
+  if (!SHARED_KEY_SET.has(key)) { cacheSet(key, value); return true; }
+  const nextValue = normalizeValueForKey(key, value);
+  const currentLocal = cacheGet(key, null);
+  const bootHydrating = !(window && window.__sharedSyncState && window.__sharedSyncState.hydrated === true);
+  if (bootHydrating && CRITICAL_BUSINESS_KEYS.has(key) && !hasMeaningfulData(nextValue) && hasMeaningfulData(currentLocal)) {
+    console.warn('[shared-kv] blocked destructive empty overwrite for critical key', { key });
+    return false;
+  }
+  if (value === undefined) {
+    const meta = { updatedAt: Date.now(), deviceId: getDeviceId() };
+    const tomb = { __deleted: true, __meta: meta };
+    cacheSet(key, undefined);
+    setMetaForKey(key, meta);
+    try {
+      await kvWriteCloud(key, tomb);
+      window.__sharedSyncState.offline = false;
+      window.__sharedSyncState.lastSyncAt = Date.now();
+      return true;
+    } catch (_) {
+      const pending = getPending();
+      pending[key] = tomb;
+      setPending(pending);
+      window.__sharedSyncState.offline = true;
+      return false;
+    }
+  }
+  const wrapped = wrapForStore(nextValue);
+  cacheSet(key, nextValue);
+  setMetaForKey(key, wrapped.__meta);
+  try {
+    await kvWriteCloud(key, wrapped);
+    window.__sharedSyncState.offline = false;
+    window.__sharedSyncState.lastSyncAt = Date.now();
+    return true;
+  } catch (_) {
+    const pending = getPending();
+    pending[key] = wrapped;
+    setPending(pending);
+    window.__sharedSyncState.offline = true;
+    return false;
+  }
+}
+
+window.sharedGet = sharedGet;
+window.sharedSet = sharedSet;
+window.readKV = sharedGet;
+window.writeKV = sharedSet;
+window.writeKVBatch = async (pairs=[]) => {
+  const out = await Promise.all((Array.isArray(pairs)?pairs:[]).map(p => sharedSet(p.key, p.value)));
+  return out.every(Boolean);
+};
+
+let __rerenderTimer = null;
+let __renderResultsTimer = null;
+window.scheduleRenderResults = function scheduleRenderResults(reason = '', delay = 120){
+  try { window.__lastRenderResultsReason = reason; } catch (_) {}
+  try { if (__renderResultsTimer) clearTimeout(__renderResultsTimer); } catch (_) {}
+  __renderResultsTimer = setTimeout(() => {
+    __renderResultsTimer = null;
+    try { if (typeof window.renderResults === 'function') window.renderResults(); } catch (_) {}
+  }, Math.max(0, Number(delay) || 0));
+};
+function queueSharedRerender(){
+  try { if (__rerenderTimer) clearTimeout(__rerenderTimer); } catch(_) {}
+  __rerenderTimer = setTimeout(() => {
+    __rerenderTimer = null;
+    try { window.refreshCoreStoresFromStorage?.(); } catch(_) {}
+    try { window.scheduleRenderResults?.('shared-realtime'); } catch(_) {}
+    try { window.renderProjects?.(); } catch(_) {}
+    try { window.renderEmployees?.(); } catch(_) {}
+    try { window.renderTable?.(); } catch(_) {}
+  }, 120);
+}
+
+async function flushPending() {
+  const pending = getPending();
+  const keys = Object.keys(pending);
+  if (!keys.length) return;
+  const remain = {};
+  for (const key of keys) {
+    const localWrapped = pending[key];
+    try {
+      const cloud = await kvReadCloud(key);
+      const cloudMeta = metaFromStore(cloud && cloud.value);
+      const localMeta = metaFromStore(localWrapped);
+      if (Number(cloudMeta.updatedAt || 0) > Number(localMeta.updatedAt || 0)) {
+        window.__sharedSyncState.conflict = true;
+        const cloudUnwrapped = unwrapFromStore(cloud && cloud.value);
+        cacheSet(key, cloudUnwrapped);
+        setMetaForKey(key, cloudMeta);
+        continue;
+      }
+      if (localWrapped && localWrapped.__deleted) {
+        await kvWriteCloud(key, localWrapped);
+        cacheSet(key, undefined);
+        setMetaForKey(key, localMeta);
+      } else {
+        await kvWriteCloud(key, localWrapped);
+        setMetaForKey(key, localMeta);
+      }
+      window.__sharedSyncState.lastSyncAt = Date.now();
+      window.__sharedSyncState.offline = false;
+    } catch (_) {
+      remain[key] = localWrapped;
+      window.__sharedSyncState.offline = true;
+    }
+  }
+  setPending(remain);
+}
+
+async function sharedHydrateAll() {
+  try {
+    const localBeforeHydrate = {};
+    for (const key of SHARED_KEYS) {
+      localBeforeHydrate[key] = cacheGet(key, null);
+    }
+    const { data, error } = await supabase.from(TABLE).select('key,value,updated_at').in('key', SHARED_KEYS);
+    if (error) throw error;
+    for (const row of (data || [])) {
+      const key = row?.key;
+      if (!key || !SHARED_KEY_SET.has(key)) continue;
+      const m = metaFromStore(row.value);
+      const unwrapped = unwrapFromStore(row.value);
+      const chosen = chooseCriticalValue(key, unwrapped, localBeforeHydrate[key]);
+      if (unwrapped === undefined) {
+        if (CRITICAL_BUSINESS_KEYS.has(key) && hasMeaningfulData(localBeforeHydrate[key])) {
+          console.warn('[shared-kv] ignored cloud tombstone for local critical data during hydrate', { key });
+          continue;
+        }
+        cacheSet(key, undefined);
+        delete metaMap[key];
+        saveMetaMap();
+      } else {
+        cacheSet(key, chosen);
+        setMetaForKey(key, m);
+      }
+    }
+    await flushPending();
+    window.__sharedSyncState.offline = false;
+  } catch (e) {
+    console.warn('sharedHydrateAll offline/failed:', e?.message || e);
+  } finally {
+    window.__sharedSyncState.hydrated = true;
+    window.__sharedSyncState.lastSyncAt = Date.now();
+    window.__kv_hydrated = true;
+    window.__kv_cloud_ready = true;
+    try { window.dispatchEvent(new Event('kv-hydrated')); window.dispatchEvent(new Event('kv-cloud-ready')); } catch (_) {}
+  }
+}
+window.sharedHydrateAll = sharedHydrateAll;
+
+function startLegacyKvRealtime() {
+  if (window.__PAYROLL_ENABLE_KV_REALTIME !== true) return null;
+  if (window.__sharedKvChannel) return window.__sharedKvChannel;
+
+  const kvChannel = supabase.channel('kv_store_realtime')
+    .on('postgres_changes', { event:'*', schema:'public', table: TABLE }, (payload) => {
+      try {
+        const eventType = payload?.eventType;
+        const row = (eventType === 'DELETE') ? payload?.old : payload?.new;
+        const key = row?.key;
+        if (!key || !SHARED_KEY_SET.has(key)) return;
+
+        if (eventType === 'DELETE') {
+          cacheSet(key, undefined);
+          delete metaMap[key];
+          saveMetaMap();
+          queueSharedRerender();
+          return;
+        }
+
+        const incomingMeta = metaFromStore(row?.value);
+        const localMeta = metaMap[key] || { updatedAt:0, deviceId:'' };
+        if (Number(incomingMeta.updatedAt || 0) < Number(localMeta.updatedAt || 0)) return;
+
+        const nextVal = unwrapFromStore(row.value);
+        if (nextVal === undefined) {
+          cacheSet(key, undefined);
+          delete metaMap[key];
+          saveMetaMap();
+        } else {
+          cacheSet(key, nextVal);
+          setMetaForKey(key, incomingMeta);
+        }
+        window.__sharedSyncState.lastSyncAt = Date.now();
+        queueSharedRerender();
+      } catch (e) {
+        console.warn('shared realtime apply failed', e);
+      }
+    });
+
+  kvChannel.subscribe();
+  window.__sharedKvChannel = kvChannel;
+  return kvChannel;
+}
+
+function stopLegacyKvRealtime() {
+  if (!window.__sharedKvChannel) return;
+  try { supabase.removeChannel(window.__sharedKvChannel); } catch (_) {}
+  window.__sharedKvChannel = null;
+}
+
+window.startLegacyKvRealtime = startLegacyKvRealtime;
+window.stopLegacyKvRealtime = stopLegacyKvRealtime;
+startLegacyKvRealtime();
+
+window.addEventListener('online', () => { flushPending().catch(() => {}); });
+
+if (!window.__sharedStorageHooked) {
+  window.__sharedStorageHooked = true;
+  window.localStorage.setItem = function patchedSetItem(key, value) {
+    if (SHARED_KEY_SET.has(key)) {
+      let parsed = value;
+      try { parsed = JSON.parse(String(value)); } catch (_) {}
+      sharedSet(key, parsed);
+      return;
+    }
+    return __origSetItem(key, value);
+  };
+  window.localStorage.removeItem = function patchedRemoveItem(key) {
+    if (SHARED_KEY_SET.has(key)) {
+      sharedSet(key, undefined);
+      return;
+    }
+    return __origRemoveItem(key);
+  };
+}
+
+</script>
 
 <!-- Style to visually lock panels when payroll data is locked.
      When #panelMain has the 'locked' class, the panel appears dimmed while
@@ -2550,7 +2968,186 @@ window.addEventListener('load', dashReports);
    <div id="dashBackupLog" style="display:none;margin:8px 0;padding:10px;border:1px solid #e5e7eb;background:#fff;border-radius:8px;font-size:12px;color:#111;line-height:1.35;max-width:920px;"></div>
   </section>
 
-  <script src="./src/legacy/backupRestore.js"></script>
+  <script>
+  // === Dashboard Full Backup & Restore ===
+  (function(){
+    const statusEl = document.getElementById('dashBackupStatus');
+    const logEl = document.getElementById('dashBackupLog');
+    const btnBackup = document.getElementById('dashBackupNow');
+    const btnRestoreFile = document.getElementById('dashRestoreFile');
+    const inputRestore = document.getElementById('dashRestoreInput');
+    // Only keep local backup and file-restore controls
+    if(!btnBackup || !btnRestoreFile || !inputRestore) return;
+
+    // Lazily resolve Supabase to avoid capturing `null` before the module loads
+    const getSupa = () => (window.supabase || null);
+    const KV_TABLE = window.SUPABASE_TABLE || 'kv_store';
+    const DTR_TABLE = 'dtr_punches';
+    const LEGACY_DTR_TABLE = 'dtr_records';
+    const BUCKET = 'backups';
+
+    function setStatus(msg, isError){ if(statusEl){ statusEl.textContent = msg; statusEl.style.color = isError?'#b91c1c':'#334155'; } }
+    function log(msg){ try{ logEl.style.display='block'; const d=document.createElement('div'); d.textContent=msg; logEl.appendChild(d);}catch(e){} }
+    function clearLog(){ try{ logEl.innerHTML=''; logEl.style.display='none'; }catch(e){} }
+    function tryJSON(v){ try{ return JSON.parse(v); }catch{ return v; } }
+
+    async function fetchKVAll(){
+      const supa = getSupa();
+      if(!supa) return { rows:[], error:'No Supabase client' };
+      try{
+        const { data, error } = await supa.from(KV_TABLE).select('key,value');
+        return { rows: data||[], error: error? error.message : null };
+      }catch(e){ return { rows:[], error: String(e) } }
+    }
+    async function fetchDTR(){
+      const supa = getSupa();
+      if(!supa) return { rows:[], error:'No Supabase client' };
+      // Prefer best-practice row-per-punch table, fallback to legacy single-row blob.
+      async function fetchPunches(){
+        const { data, error } = await supa.from(DTR_TABLE).select('id,data').range(0, 9999);
+        if(error) throw error;
+        if(Array.isArray(data) && data.length){
+          // If this is the legacy single-row shape mistakenly stored here:
+          if(data.length === 1 && data[0] && data[0].id === 'records'){
+            const payload = data[0].data;
+            if(Array.isArray(payload)) return payload;
+            if(payload && typeof payload === 'object' && Array.isArray(payload.records)) return payload.records;
+          }
+          // Row-per-punch: each row's `data` is the punch object
+          const recs = data.map(r=>r && r.data).filter(Boolean);
+          return recs;
+        }
+        return [];
+      }
+      async function fetchLegacy(){
+        const { data, error } = await supa.from(LEGACY_DTR_TABLE).select('data').eq('id','records').maybeSingle();
+        if(error) throw error;
+        if(!data) return [];
+        const payload = data.data;
+        if(Array.isArray(payload)) return payload;
+        if(payload && typeof payload === 'object' && Array.isArray(payload.records)) return payload.records;
+        return [];
+      }
+      try{
+        const recs = await fetchPunches();
+        return { rows: recs, error: null };
+      }catch(e){
+        const msg = (e && (e.message || e.details)) ? String(e.message || e.details) : String(e);
+        // If punches table is missing, try legacy
+        try{
+          const recs = await fetchLegacy();
+          return { rows: recs, error: null };
+        }catch(e2){
+          return { rows:[], error: msg };
+        }
+      }
+    }
+
+
+    function snapshotLocalStorage(){
+      const kv = {};
+      try{
+        for(let i=0;i<localStorage.length;i++){
+          const k = localStorage.key(i);
+          if(!k || k.startsWith('__') || k.startsWith('vscode')) continue;
+          kv[k] = tryJSON(localStorage.getItem(k));
+        }
+      }catch(e){}
+      return kv;
+    }
+
+    async function buildBundle(){
+      clearLog(); setStatus('Building backup...', false);
+      const ls = snapshotLocalStorage();
+      log('Collected localStorage keys: ' + Object.keys(ls).length);
+      const kvRes = await fetchKVAll(); if(kvRes.error) log('KV fetch warning: ' + kvRes.error); else log('KV rows: ' + kvRes.rows.length);
+      const dtrRes = await fetchDTR(); if(dtrRes.error) log('DTR fetch warning: ' + dtrRes.error); else log('DTR rows: ' + dtrRes.rows.length);
+      const bundle = {
+        schema: 'payrollhub.full.v1',
+        created_at: new Date().toISOString(),
+        localStorage: ls,
+        kv: kvRes.rows||[],
+        dtr: dtrRes.rows||[]
+      };
+      return bundle;
+    }
+
+    async function uploadBundleToCloud(bundle){
+      const supa = getSupa();
+      if(!supa || !supa.storage){ log('No Supabase storage client (skipping cloud upload)'); return null; }
+      try{
+        const json = JSON.stringify(bundle);
+        const name = 'full_backup_' + new Date().toISOString().replace(/[:.]/g,'_') + '.json';
+        const blob = new Blob([json], { type: 'application/json' });
+        const { error } = await supa.storage.from(BUCKET).upload(name, blob, { upsert: true, contentType: 'application/json' });
+        if(error){ log('Upload failed: ' + error.message); return null; }
+        log('Uploaded to storage: ' + name);
+        return name;
+      }catch(e){ log('Upload failed: ' + String(e)); return null; }
+    }
+
+    // Cloud listing removed
+
+    function applyLocalStorage(ls){
+      try{ Object.keys(ls||{}).forEach(k=>{ try{ localStorage.setItem(k, JSON.stringify(ls[k])); }catch(_){} }); }catch(e){}
+    }
+    async function applyKV(kv){
+      const supa = getSupa();
+      if(!supa) return;
+      try{
+        for(const row of (kv||[])){
+          if(!row || !row.key) continue;
+          try{ await supa.from(KV_TABLE).upsert({ key: row.key, value: row.value }, { onConflict: 'key' }); }catch(_){}
+        }
+      }catch(e){ log('KV upsert error: ' + String(e)); }
+    }
+    async function applyDTR(rows){
+      const supa = getSupa();
+      if(!supa) return;
+      try{
+        await supa.from(DTR_TABLE).upsert({ id:'records', data: Array.isArray(rows)?rows:[] }, { onConflict:'id' });
+        window.storedRecords = Array.isArray(rows)?rows:[];
+        try{ if (window.sharedSet) window.sharedSet('att_records_v2', window.storedRecords); else localStorage.setItem('att_records_v2', JSON.stringify(window.storedRecords)); }catch(_){ }
+      }catch(e){ log('DTR upsert error: ' + String(e)); }
+    }
+
+    btnBackup.addEventListener('click', async ()=>{
+      btnBackup.disabled = true; setStatus('Building backup...', false); clearLog();
+      try{
+        const bundle = await buildBundle();
+        // Download locally
+        try{
+          const url = URL.createObjectURL(new Blob([JSON.stringify(bundle)],{type:'application/json'}));
+          const a=document.createElement('a'); a.href=url; a.download='payroll_full_backup_'+ new Date().toISOString().slice(0,10)+'.json'; a.click(); setTimeout(()=>URL.revokeObjectURL(url), 1500);
+          log('Downloaded local backup');
+        }catch(e){ log('Local download failed: ' + String(e)); }
+        // Upload to cloud
+        await uploadBundleToCloud(bundle);
+        setStatus('Backup complete', false);
+      }catch(e){ setStatus('Backup error: ' + String(e), true); }
+      finally{ btnBackup.disabled = false; }
+    });
+
+    btnRestoreFile.addEventListener('click', ()=> inputRestore.click());
+    inputRestore.addEventListener('change', async (ev)=>{
+      const f = ev.target.files && ev.target.files[0]; ev.target.value=''; if(!f) return;
+      setStatus('Restoring from file...', false); clearLog();
+      try{
+        const text = await f.text(); const bundle = JSON.parse(text||'{}');
+        if(!bundle || bundle.schema !== 'payrollhub.full.v1') throw new Error('Invalid bundle schema');
+        applyLocalStorage(bundle.localStorage || {}); log('Applied localStorage');
+        await applyKV(bundle.kv || []); log('Applied KV table');
+        await applyDTR(bundle.dtr || []); log('Applied DTR rows');
+        setStatus('Restore complete', false); alert('Restore complete.');
+      }catch(e){ setStatus('Restore failed: ' + String(e), true); alert('Restore failed: ' + String(e)); }
+    });
+
+    // Cloud restore removed
+  })();
+  // === / Dashboard Full Backup & Restore ===
+  
+
+</script>
 
   <!-- Original Main panel (DTR) no longer active by default -->
   <section class="panel" id="panelMain">
@@ -25100,8 +25697,2012 @@ document.addEventListener('DOMContentLoaded', function(){
 })();
 </script>
 
-<script src="./src/legacy/auditTab.js"></script>
+<script>
+// === Audit tab (finalized periods): load + verify hash + view stored snapshot segments ===
+(function(){
+  function $(id){ return document.getElementById(id); }
 
-<script type="module" src="./src/main.js"></script>
+  function setStatus(msg, isErr){
+    const el = $('auditStatus');
+    if (!el) return;
+    el.textContent = msg || '';
+    el.style.color = isErr ? '#b91c1c' : '#64748b';
+  }
+
+  function setInfo(html){
+    const el = $('auditInfo');
+    if (!el) return;
+    el.innerHTML = html || '';
+  }
+
+  function resetAuditTabs(){
+    const tabs = $('auditTabs');
+    if (tabs) {
+      tabs.innerHTML = '';
+      tabs.style.display = 'none';
+    }
+  }
+
+  function setActiveAuditSubtab(name){
+    const cont = $('auditContainer');
+    const tabs = $('auditTabs');
+    if (!cont || !tabs) return;
+
+    tabs.querySelectorAll('.tab-btn').forEach(btn=>{
+      const active = btn.dataset.seg === name;
+      btn.classList.toggle('active', active);
+      btn.setAttribute('aria-selected', active ? 'true' : 'false');
+    });
+
+    cont.querySelectorAll('[data-audit-segment]').forEach(card=>{
+      card.style.display = (card.dataset.auditSegment === name) ? '' : 'none';
+    });
+  }
+
+  function renderAuditSubtabs(segNames){
+    const tabs = $('auditTabs');
+    if (!tabs) return;
+    tabs.innerHTML = '';
+
+    if (!Array.isArray(segNames) || !segNames.length) {
+      tabs.style.display = 'none';
+      return;
+    }
+
+    segNames.forEach((name, idx)=>{
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'tab-btn' + (idx === 0 ? ' active' : '');
+      btn.dataset.seg = name;
+      btn.setAttribute('aria-selected', idx === 0 ? 'true' : 'false');
+      btn.textContent = name;
+      btn.addEventListener('click', ()=>setActiveAuditSubtab(name));
+      tabs.appendChild(btn);
+    });
+
+    tabs.style.display = 'flex';
+  }
+
+  function fmtStamp(iso){
+    if (!iso) return '';
+    try { return new Date(iso).toLocaleString(); } catch(e){ return String(iso); }
+  }
+
+  async function loadAuditIndex(){
+    const sel = $('auditPeriodSelect');
+    if (!sel) return [];
+    sel.innerHTML = '';
+
+    let idx = [];
+    try {
+      const revRows = (window.store && window.store.getJSON('payroll_period_snapshots_v1', [])) || [];
+      idx = revRows.map(r => ({
+        startDate: (r.period_id || '').split('|')[0] || '',
+        endDate: (r.period_id || '').split('|')[1] || '',
+        revision: r.revision || 1,
+        status: r.status || 'FINALIZED',
+        finalizedAt: r.created_at || '',
+        hash: r.snapshot_hash || '',
+        period_id: r.period_id || '',
+        snapshot_data: r.snapshot_data || null
+      }));
+    } catch (e) {}
+
+    if (!Array.isArray(idx) || !idx.length) {
+      try { if (typeof window.readSnapshotIndex === 'function') idx = await window.readSnapshotIndex(); } catch (e) {}
+    }
+    if (!Array.isArray(idx)) idx = [];
+
+    idx = idx.filter(it => it && (it.finalizedAt || it.lockedAt || it.created_at));
+
+    idx.sort((a,b)=>{
+      const as = (a.finalizedAt || a.lockedAt || a.createdAt || a.created_at || '');
+      const bs = (b.finalizedAt || b.lockedAt || b.createdAt || b.created_at || '');
+      return String(bs).localeCompare(String(as));
+    });
+
+    if (!idx.length){
+      const opt = document.createElement('option');
+      opt.value = '';
+      opt.textContent = 'No finalized snapshots found';
+      sel.appendChild(opt);
+      setStatus('No snapshots.');
+      setInfo('');
+      const pre = $('auditManifestJson'); if (pre) pre.textContent = '';
+      const cont = $('auditContainer'); if (cont) cont.innerHTML = '';
+      resetAuditTabs();
+      return [];
+    }
+
+    idx.forEach(item=>{
+      const s = item.startDate || '';
+      const e = item.endDate || '';
+      const opt = document.createElement('option');
+      const rev = item.revision || 1;
+      opt.value = [s,e,rev].join('|');
+      const hash = item.auditHash || item.hash || '';
+      const status = item.status || 'FINALIZED';
+      opt.textContent = (s && e ? (s + ' to ' + e) : (s || e || 'Period')) + ` • Rev ${rev} • ${status}` + (hash ? (' • ' + String(hash).slice(0,10) + '…') : '');
+      sel.appendChild(opt);
+    });
+
+    setStatus('Loaded ' + idx.length + ' snapshot(s).');
+    return idx;
+  }
+
+  async function showSelectedManifest(){
+    const sel = $('auditPeriodSelect');
+    if (!sel) return;
+    const val = sel.value || '';
+    const parts = val.split('|');
+    const startDate = parts[0] || '';
+    const endDate = parts[1] || '';
+    const revision = Number(parts[2] || '1');
+    if (!startDate || !endDate) return;
+
+    const pre  = $('auditManifestJson');
+    const cont = $('auditContainer');
+    if (cont) cont.innerHTML = '';
+    resetAuditTabs();
+
+    let manifest = null;
+    try { if (typeof window.readSnapshotSegment === 'function') manifest = await window.readSnapshotSegment('manifest', startDate, endDate); } catch(e){}
+
+    if (!manifest) {
+      let idx = [];
+      try { idx = await window.readSnapshotIndex(); } catch(e){}
+      const entry = (Array.isArray(idx) ? idx : []).find(x => x && x.startDate === startDate && x.endDate === endDate && (!revision || Number(x.revision||1)===revision)) || {};
+      manifest = {
+        version: entry.version || 0,
+        startDate, endDate,
+        finalizedAt: entry.finalizedAt || entry.lockedAt || '',
+        rootHash: entry.auditHash || entry.hash || '',
+        note: 'Manifest not found for this period. (Older snapshot?)',
+        auditHash: entry.auditHash || '',
+        manifestHash: entry.manifestHash || '',
+        segmentCount: entry.segmentCount || 0
+      };
+    }
+
+    const hash = manifest.rootHash || manifest.auditHash || '';
+    const when = manifest.finalizedAt ? fmtStamp(manifest.finalizedAt) : '';
+    setInfo(
+      '<div><b>Period:</b> ' + startDate + ' to ' + endDate + '</div>' +
+      (when ? ('<div><b>Finalized:</b> ' + when + '</div>') : '') +
+      (hash ? ('<div><b>Root Hash:</b> <code style="font-size:12px;">' + hash + '</code></div>') : '') +
+      (manifest.segmentCount ? ('<div><b>Segments:</b> ' + manifest.segmentCount + '</div>') : '') +
+      (manifest.note ? ('<div style="margin-top:6px;color:#64748b;">' + String(manifest.note) + '</div>') : '')
+    );
+
+    if (pre) pre.textContent = JSON.stringify(manifest, null, 2);
+  }
+
+  async function auditVerify(){
+    const sel = $('auditPeriodSelect');
+    if (!sel) return;
+    const val = sel.value || '';
+    const parts = val.split('|');
+    const startDate = parts[0] || '';
+    const endDate = parts[1] || '';
+    const revision = Number(parts[2] || '1');
+    if (!startDate || !endDate) return;
+
+    setStatus('Verifying…');
+    try {
+      const rows = (window.store && window.store.getJSON('payroll_period_snapshots_v1', [])) || [];
+      const periodId = `${startDate}|${endDate}`;
+      const row = rows.find(r => r && r.period_id === periodId && Number(r.revision||1) === revision);
+      if (row && row.snapshot_data) {
+        const computed = await (window.computeSnapshotHash ? window.computeSnapshotHash(row.snapshot_data) : Promise.resolve(''));
+        if (computed && computed === row.snapshot_hash) setStatus('✅ Verified');
+        else setStatus('❌ Mismatch', true);
+      } else if (typeof window.verifyAuditManifestForPeriod === 'function') {
+        const res = await window.verifyAuditManifestForPeriod(startDate, endDate);
+        if (res && res.ok) setStatus('✅ Hash OK (matches manifest)');
+        else setStatus('❌ Hash FAILED: ' + ((res && res.reason) ? res.reason : 'Mismatch'), true);
+      } else {
+        setStatus('No verifiable snapshot found', true);
+      }
+      await showSelectedManifest();
+    } catch (e) {
+      setStatus('Verify error: ' + (e && e.message ? e.message : String(e)), true);
+    }
+  }
+
+  function renderSegmentCard(name, value){
+    const card = document.createElement('div');
+    card.className = 'audit-segment-card';
+    card.dataset.auditSegment = name;
+    card.style.border = '1px solid #e2e8f0';
+    card.style.borderRadius = '12px';
+    card.style.padding = '10px';
+    card.style.background = '#fff';
+
+    const title = document.createElement('div');
+    title.className = 'audit-segment-title';
+    title.style.fontWeight = '700';
+    title.style.marginBottom = '6px';
+    title.textContent = name;
+    card.appendChild(title);
+
+    if (value && typeof value === 'object' && Array.isArray(value.headers) && Array.isArray(value.rows)) {
+      const html = (typeof window.buildTableHtml === 'function')
+        ? window.buildTableHtml(value.headers, value.rows, value.footerRow || [])
+        : '';
+      const wrap = document.createElement('div');
+      wrap.className = 'audit-segment-wrap';
+      wrap.style.overflow = 'auto';
+      wrap.innerHTML = html || '<div class="audit-table-unavailable" style="color:#64748b;font-size:12px;">(Table renderer unavailable)</div>';
+      card.appendChild(wrap);
+      return card;
+    }
+
+    if (value && typeof value === 'object' && typeof value.html === 'string') {
+      const det = document.createElement('details');
+      det.open = false;
+      const sum = document.createElement('summary');
+      sum.textContent = 'View HTML';
+      sum.style.cursor = 'pointer';
+      det.appendChild(sum);
+      const wrap = document.createElement('div');
+      wrap.className = 'audit-segment-wrap';
+      wrap.style.overflow = 'auto';
+      wrap.innerHTML = value.html;
+      det.appendChild(wrap);
+      card.appendChild(det);
+      return card;
+    }
+
+    const pre = document.createElement('pre');
+    pre.className = 'audit-raw-pre';
+    pre.style.whiteSpace = 'pre-wrap';
+    pre.style.margin = '0';
+    pre.style.fontSize = '12px';
+    pre.textContent = (typeof value === 'string') ? value : JSON.stringify(value, null, 2);
+    card.appendChild(pre);
+    return card;
+  }
+
+  async function auditLoadSnapshot(){
+    const sel = $('auditPeriodSelect');
+    const cont = $('auditContainer');
+    if (!sel || !cont) return;
+    const val = sel.value || '';
+    const parts = val.split('|');
+    const startDate = parts[0] || '';
+    const endDate = parts[1] || '';
+    const revision = Number(parts[2] || '1');
+    if (!startDate || !endDate) return;
+
+    if (typeof window.readSnapshotSegment !== 'function') {
+      setStatus('readSnapshotSegment not available', true);
+      return;
+    }
+
+    setStatus('Loading snapshot…');
+    cont.innerHTML = '';
+
+    let manifest = null;
+    try { manifest = await window.readSnapshotSegment('manifest', startDate, endDate); } catch(e){}
+    const segNames = manifest && manifest.segmentHashes ? Object.keys(manifest.segmentHashes) : ['dtr','payroll','overtime','deductions','additionalIncome','otherDeductions','adjustments','reports','master'];
+    const rendered = [];
+
+    for (const name of segNames) {
+      try {
+        const seg = await window.readSnapshotSegment(name, startDate, endDate);
+        if (seg == null) continue;
+        cont.appendChild(renderSegmentCard(name, seg));
+        rendered.push(name);
+      } catch (e) {
+        cont.appendChild(renderSegmentCard(name, { error: (e && e.message) ? e.message : String(e) }));
+        rendered.push(name);
+      }
+    }
+
+    resetAuditTabs();
+    cont.querySelectorAll('[data-audit-segment]').forEach(card=>{ card.style.display = ''; });
+    setStatus(rendered.length ? ('Loaded ' + rendered.length + ' segment(s).') : 'No stored segments found.');
+  }
+
+  window.renderAuditPanel = async function(){
+    await loadAuditIndex();
+    await showSelectedManifest();
+
+    const sel = $('auditPeriodSelect');
+    if (sel && !sel.__auditWired) {
+      sel.addEventListener('change', showSelectedManifest);
+      sel.__auditWired = true;
+    }
+    const b1 = $('auditRefreshBtn');
+    const b2 = $('auditVerifyBtn');
+    const b3 = $('auditLoadBtn');
+    if (b1 && !b1.__auditWired) { b1.addEventListener('click', async()=>{ await loadAuditIndex(); await showSelectedManifest(); }); b1.__auditWired = true; }
+    if (b2 && !b2.__auditWired) { b2.addEventListener('click', auditVerify); b2.__auditWired = true; }
+    if (b3 && !b3.__auditWired) { b3.addEventListener('click', auditLoadSnapshot); b3.__auditWired = true; }
+  };
+})();
+
+</script>
+
+<script>
+(() => {
+  var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, {
+    get: (a, b) => (typeof require !== "undefined" ? require : a)[b]
+  }) : x)(function(x) {
+    if (typeof require !== "undefined")
+      return require.apply(this, arguments);
+    throw Error('Dynamic require of "' + x + '" is not supported');
+  });
+
+  // src/config/supabaseClient.js
+  var import_supabase_js_2_bundle = __require("https://esm.sh/@supabase/supabase-js@2?bundle");
+  function isSupabaseClient(client) {
+    return !!(client && typeof client.from === "function" && typeof client.channel === "function");
+  }
+  var cachedSupabaseClient = null;
+  var DEFAULT_SUPABASE_URL = "https://qzkzugzfpegozpiqutdv.supabase.co";
+  var DEFAULT_SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InF6a3p1Z3pmcGVnb3pwaXF1dGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTU4MTc5MDMsImV4cCI6MjA3MTM5MzkwM30.mdFYuFjbRfsILWPkQQmVUCDR7dGqEo-mdPZ6iwolvGk";
+  function getSupabaseClient() {
+    if (isSupabaseClient(cachedSupabaseClient))
+      return cachedSupabaseClient;
+    if (isSupabaseClient(window.supabase)) {
+      cachedSupabaseClient = window.supabase;
+      return cachedSupabaseClient;
+    }
+    const SUPABASE_URL = window.SUPABASE_URL || DEFAULT_SUPABASE_URL;
+    const SUPABASE_KEY = window.SUPABASE_KEY || DEFAULT_SUPABASE_KEY;
+    cachedSupabaseClient = import_supabase_js_2_bundle.createClient(SUPABASE_URL, SUPABASE_KEY, {
+      auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false }
+    });
+    window.supabase = cachedSupabaseClient;
+    return cachedSupabaseClient;
+  }
+  async function waitForSupabaseClient({ timeoutMs = 6000, intervalMs = 50 } = {}) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      const client = getSupabaseClient();
+      if (client)
+        return client;
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+    return null;
+  }
+
+  // src/config/featureFlags.js
+  var LOCAL_FLAGS_KEY = "payroll_feature_flags";
+  function readLocalFlags() {
+    try {
+      const raw = window.localStorage?.getItem(LOCAL_FLAGS_KEY);
+      if (!raw)
+        return null;
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+        return null;
+      return parsed;
+    } catch (_) {
+      return null;
+    }
+  }
+  function readRuntimeFlags() {
+    const runtime = window.__PAYROLL_FLAGS;
+    if (!runtime || typeof runtime !== "object" || Array.isArray(runtime))
+      return null;
+    return runtime;
+  }
+  function readEnvFlag(name) {
+    const env = typeof import.meta !== "undefined" && import.meta?.env || typeof process !== "undefined" && process?.env || null;
+    if (!env || !Object.prototype.hasOwnProperty.call(env, name))
+      return null;
+    const value = env[name];
+    if (typeof value === "string") {
+      const normalized = value.trim().toLowerCase();
+      return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+    }
+    return !!value;
+  }
+  function getFeatureFlag(name, fallback = false) {
+    const runtime = readRuntimeFlags();
+    if (runtime && Object.prototype.hasOwnProperty.call(runtime, name)) {
+      return !!runtime[name];
+    }
+    const env = readEnvFlag(name);
+    if (env != null) {
+      return env;
+    }
+    const local = readLocalFlags();
+    if (local && Object.prototype.hasOwnProperty.call(local, name)) {
+      return !!local[name];
+    }
+    return !!fallback;
+  }
+
+  // src/state/store.js
+  var initialState = {
+    currentPeriodId: null,
+    payrollPeriods: new Map,
+    payrollSnapshots: new Map,
+    dtrRecords: new Map,
+    dtrPunches: new Map,
+    employees: new Map,
+    projects: new Map,
+    schedules: new Map,
+    loans: new Map,
+    loanDeductions: new Map,
+    contribFlags: new Map,
+    profiles: new Map,
+    diagnostics: {
+      supabaseConnected: null,
+      realtimeStatus: "idle",
+      currentPeriodLocked: null,
+      periodBootstrapPending: true,
+      periodSwitchInFlight: false,
+      periodSwitchError: null,
+      lastRealtimeEvent: null,
+      lastConflict: null,
+      activeChannelCount: 0,
+      activeRealtimeGroups: [],
+      activeRealtimeTables: [],
+      eventsByTable: {},
+      degradedModeEnabled: false
+    }
+  };
+  var state = structuredClone(initialState);
+  var listeners = new Set;
+  var batchDepth = 0;
+  var pendingChanges = [];
+  function getState() {
+    return state;
+  }
+  function subscribe(listener) {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  }
+  function notify(change) {
+    if (batchDepth > 0) {
+      pendingChanges.push(change);
+      return;
+    }
+    listeners.forEach((listener) => listener(state, change));
+  }
+  function batch(fn) {
+    batchDepth += 1;
+    try {
+      return fn();
+    } finally {
+      batchDepth -= 1;
+      if (batchDepth === 0 && pendingChanges.length) {
+        const changes = pendingChanges;
+        pendingChanges = [];
+        notify({ type: "batch", changes });
+      }
+    }
+  }
+  function setCurrentPeriod(periodId) {
+    state.currentPeriodId = periodId;
+    const period = periodId ? state.payrollPeriods.get(periodId) : null;
+    state.diagnostics.currentPeriodLocked = period ? !!period.is_locked : null;
+    notify({ type: "set_current_period", periodId });
+  }
+  function setPeriodBootstrapPending(pending) {
+    state.diagnostics.periodBootstrapPending = !!pending;
+    notify({ type: "diagnostics_period_bootstrap_pending", pending: !!pending });
+  }
+  function setPeriodSwitchInFlight(inFlight) {
+    state.diagnostics.periodSwitchInFlight = !!inFlight;
+    notify({ type: "diagnostics_period_switch_in_flight", inFlight: !!inFlight });
+  }
+  function clearPeriodSwitchError() {
+    state.diagnostics.periodSwitchError = null;
+    notify({ type: "diagnostics_period_switch_error_clear" });
+  }
+  function setPeriodSwitchError(message) {
+    state.diagnostics.periodSwitchError = message ? String(message) : "Unknown period switch error";
+    notify({ type: "diagnostics_period_switch_error", message: state.diagnostics.periodSwitchError });
+  }
+  function mergeRow(tableKey, row, primaryKey = "id") {
+    if (!row || !row[primaryKey])
+      return;
+    const collection = state[tableKey];
+    if (!(collection instanceof Map)) {
+      throw new Error(`Unknown table key: ${tableKey}`);
+    }
+    const prev = collection.get(row[primaryKey]) || {};
+    collection.set(row[primaryKey], { ...prev, ...row });
+    if (tableKey === "payrollPeriods" && row.id === state.currentPeriodId) {
+      state.diagnostics.currentPeriodLocked = !!row.is_locked;
+    }
+    notify({ type: "merge_row", tableKey, row });
+  }
+  function removeRow(tableKey, id) {
+    const collection = state[tableKey];
+    if (!(collection instanceof Map) || !id)
+      return;
+    collection.delete(id);
+    notify({ type: "remove_row", tableKey, id });
+  }
+  function resetTable(tableKey) {
+    const collection = state[tableKey];
+    if (!(collection instanceof Map))
+      return;
+    collection.clear();
+    notify({ type: "reset_table", tableKey });
+  }
+  function setSupabaseConnected(connected) {
+    state.diagnostics.supabaseConnected = !!connected;
+    notify({ type: "diagnostics_supabase_connected", connected: !!connected });
+  }
+  function setRealtimeStatus(status) {
+    state.diagnostics.realtimeStatus = status;
+    notify({ type: "diagnostics_realtime_status", status });
+  }
+  function setLastRealtimeEvent(event) {
+    state.diagnostics.lastRealtimeEvent = event;
+    notify({ type: "diagnostics_realtime_event", event });
+  }
+  function reportConflict(conflict) {
+    state.diagnostics.lastConflict = conflict;
+    notify({ type: "diagnostics_conflict", conflict });
+  }
+  function clearConflict() {
+    state.diagnostics.lastConflict = null;
+    notify({ type: "diagnostics_conflict_clear" });
+  }
+  function setRealtimeDiagnostics(patch = {}) {
+    state.diagnostics = { ...state.diagnostics, ...patch };
+    notify({ type: "diagnostics_realtime_details", patch });
+  }
+  function incrementRealtimeTableEvent(table) {
+    if (!table)
+      return;
+    const next = { ...state.diagnostics.eventsByTable || {} };
+    next[table] = (next[table] || 0) + 1;
+    state.diagnostics.eventsByTable = next;
+    notify({ type: "diagnostics_realtime_table_event", table, count: next[table] });
+  }
+
+  // src/services/payrollService.js
+  class StaleWriteError extends Error {
+    constructor(message, context = {}) {
+      super(message);
+      this.name = "StaleWriteError";
+      this.context = context;
+    }
+  }
+  function summarizePayload(payload) {
+    if (!payload || typeof payload !== "object")
+      return payload;
+    const summary = {};
+    for (const key of ["id", "payroll_period_id", "employee_id", "project_id", "loan_id", "updated_at"]) {
+      if (key in payload)
+        summary[key] = payload[key];
+    }
+    return summary;
+  }
+  function logWrite(action, table, payload) {
+    console.info("[payroll:write]", { action, table, payload: summarizePayload(payload), at: new Date().toISOString() });
+  }
+  var TABLES = {
+    periods: "payroll_periods",
+    snapshots: "payroll_period_snapshots",
+    dtr: "pp_dtr_records",
+    punches: "dtr_punches",
+    employees: "pp_employees",
+    projects: "pp_projects",
+    schedules: "pp_schedules",
+    loans: "employee_loans",
+    loanDeductions: "loan_deductions",
+    contribFlags: "pp_contrib_flags",
+    profiles: "profiles"
+  };
+  var TABLE_LOADERS = {
+    dtrRecords: { table: TABLES.dtr, stateKey: "dtrRecords" },
+    employees: { table: TABLES.employees, stateKey: "employees" },
+    projects: { table: TABLES.projects, stateKey: "projects" },
+    schedules: { table: TABLES.schedules, stateKey: "schedules" },
+    loans: { table: TABLES.loans, stateKey: "loans" },
+    loanDeductions: { table: TABLES.loanDeductions, stateKey: "loanDeductions" },
+    contribFlags: { table: TABLES.contribFlags, stateKey: "contribFlags" },
+    profiles: { table: TABLES.profiles, stateKey: "profiles" }
+  };
+  var OPTIMIZED_LOAD_FLAG = "USE_OPTIMIZED_LOAD";
+  var PAGE_SIZE = 1000;
+  var PERIOD_COLUMN = "payroll_period_id";
+  function hasOwn(row, key) {
+    return Object.prototype.hasOwnProperty.call(row || {}, key);
+  }
+  function sortRowsByKnownTimestamp(table, rows) {
+    if (table !== TABLES.punches)
+      return rows;
+    rows.sort((a, b) => {
+      const aStamp = a?.punch_at || `${a?.date || ""} ${a?.time || ""}`;
+      const bStamp = b?.punch_at || `${b?.date || ""} ${b?.time || ""}`;
+      return String(aStamp).localeCompare(String(bStamp));
+    });
+    return rows;
+  }
+  async function fetchTablePage({ table, from, to, periodId, optimized }) {
+    let query = requireSupabaseClient().from(table).select("*").range(from, to);
+    if (optimized && periodId) {
+      query = query.eq(PERIOD_COLUMN, periodId);
+    }
+    return query;
+  }
+  async function fetchAllRowsPaginated({ table, periodId, optimized }) {
+    const rows = [];
+    let page = 0;
+    for (;; ) {
+      const from = page * PAGE_SIZE;
+      const to = from + PAGE_SIZE - 1;
+      const { data, error } = await fetchTablePage({ table, from, to, periodId, optimized });
+      if (error) {
+        return { data: null, error };
+      }
+      const pageRows = Array.isArray(data) ? data : [];
+      rows.push(...pageRows);
+      if (pageRows.length < PAGE_SIZE)
+        break;
+      page += 1;
+    }
+    return { data: sortRowsByKnownTimestamp(table, rows), error: null };
+  }
+  function getPeriodCoverage(rows, periodId) {
+    const list = Array.isArray(rows) ? rows : [];
+    const withPeriodId = list.filter((row) => hasOwn(row, PERIOD_COLUMN) && row?.[PERIOD_COLUMN]);
+    const missingPeriodId = list.filter((row) => !hasOwn(row, PERIOD_COLUMN) || !row?.[PERIOD_COLUMN]);
+    const matched = withPeriodId.filter((row) => row[PERIOD_COLUMN] === periodId);
+    return {
+      total: list.length,
+      withPeriodId: withPeriodId.length,
+      missingPeriodId: missingPeriodId.length,
+      matched: matched.length,
+      hasLegacyRows: missingPeriodId.length > 0
+    };
+  }
+  async function loadRowsWithOptionalOptimizedFilter(table, periodId) {
+    const useOptimized = getFeatureFlag(OPTIMIZED_LOAD_FLAG, false);
+    if (!useOptimized || !periodId) {
+      return fetchAllRowsPaginated({ table, periodId, optimized: false });
+    }
+    const optimizedResult = await fetchAllRowsPaginated({ table, periodId, optimized: true });
+    if (!optimizedResult.error) {
+      return optimizedResult;
+    }
+    console.warn("[payroll:read:fallback] optimized query failed, falling back to legacy query", {
+      table,
+      code: optimizedResult.error.code,
+      message: optimizedResult.error.message
+    });
+    return fetchAllRowsPaginated({ table, periodId, optimized: false });
+  }
+  async function debugVerifyPeriodLoad(table, periodId) {
+    const useOptimized = getFeatureFlag(OPTIMIZED_LOAD_FLAG, false);
+    if (!useOptimized || !periodId)
+      return;
+    try {
+      const legacy = await fetchAllRowsPaginated({ table, periodId, optimized: false });
+      const optimized = await fetchAllRowsPaginated({ table, periodId, optimized: true });
+      if (legacy.error || optimized.error)
+        return;
+      const legacyCoverage = getPeriodCoverage(legacy.data, periodId);
+      const optimizedCoverage = getPeriodCoverage(optimized.data, periodId);
+      const shouldFallback = legacyCoverage.hasLegacyRows;
+      if (shouldFallback) {
+        console.warn("[payroll:verify] legacy rows without payroll_period_id detected; optimized filtering may omit rows", {
+          table,
+          periodId,
+          legacyCoverage,
+          optimizedCoverage
+        });
+        return;
+      }
+      if (legacyCoverage.matched !== optimizedCoverage.total) {
+        console.warn("[payroll:verify] row count mismatch between legacy and optimized loads", {
+          table,
+          periodId,
+          legacyMatched: legacyCoverage.matched,
+          optimizedCount: optimizedCoverage.total
+        });
+      }
+      const legacyTotal = (legacy.data || []).reduce((sum, row) => {
+        const gross = Number(row?.gross_pay || 0);
+        const net = Number(row?.net_pay || 0);
+        return sum + gross + net;
+      }, 0);
+      const optimizedTotal = (optimized.data || []).reduce((sum, row) => {
+        const gross = Number(row?.gross_pay || 0);
+        const net = Number(row?.net_pay || 0);
+        return sum + gross + net;
+      }, 0);
+      if (Math.abs(legacyTotal - optimizedTotal) > 0.0001) {
+        console.warn("[payroll:verify] totals mismatch between legacy and optimized loads", {
+          table,
+          periodId,
+          legacyTotal,
+          optimizedTotal
+        });
+      }
+    } catch (error) {
+      console.warn("[payroll:verify] debug verify failed", { table, periodId, message: error?.message || String(error) });
+    }
+  }
+  async function fetchPunchRowsByKnownShapes(periodId) {
+    const useScopedReads = getFeatureFlag("payroll_ff_scoped_reads_v1", false) || getFeatureFlag(OPTIMIZED_LOAD_FLAG, false);
+    if (useScopedReads && periodId) {
+      const scoped = await loadRowsWithOptionalOptimizedFilter(TABLES.punches, periodId);
+      if (!scoped.error) {
+        const coverage = getPeriodCoverage(scoped.data, periodId);
+        if (!coverage.hasLegacyRows) {
+          debugVerifyPeriodLoad(TABLES.punches, periodId);
+          return scoped;
+        }
+        console.warn("[payroll:read:fallback] scoped punches omitted legacy rows, falling back to legacy full fetch", {
+          periodId,
+          coverage
+        });
+      } else {
+        console.warn("[payroll:read:fallback] scoped punches query failed, falling back to legacy full fetch", {
+          code: scoped.error.code,
+          message: scoped.error.message
+        });
+      }
+    }
+    const legacy = await fetchAllRowsPaginated({ table: TABLES.punches, periodId, optimized: false });
+    if (legacy.error)
+      return legacy;
+    const rows = Array.isArray(legacy.data) ? legacy.data : [];
+    const hasPeriodColumn = rows.some((row) => hasOwn(row, PERIOD_COLUMN));
+    let filtered = rows;
+    if (periodId && hasPeriodColumn) {
+      filtered = rows.filter((row) => row?.payroll_period_id === periodId);
+    }
+    sortRowsByKnownTimestamp(TABLES.punches, filtered);
+    debugVerifyPeriodLoad(TABLES.punches, periodId);
+    return { data: filtered, error: null };
+  }
+  function requireSupabaseClient() {
+    const client = getSupabaseClient();
+    if (!client) {
+      throw new Error("Supabase client is not ready. Ensure the legacy bootstrap initialized window.supabase.");
+    }
+    return client;
+  }
+  var hasRpcLockGuard = null;
+  async function ensurePeriodUnlockedWithRpc(periodId) {
+    if (!periodId)
+      return;
+    const client = requireSupabaseClient();
+    if (hasRpcLockGuard !== false) {
+      const { error } = await client.rpc("assert_payroll_period_unlocked", { p_period_id: periodId });
+      if (!error) {
+        hasRpcLockGuard = true;
+        return;
+      }
+      const message = String(error?.message || "");
+      const missingRpc = error.code === "PGRST202" || /function .*assert_payroll_period_unlocked/i.test(message);
+      if (!missingRpc)
+        throw error;
+      hasRpcLockGuard = false;
+      console.warn("[payroll:lock-guard] RPC assert_payroll_period_unlocked is unavailable; using client-side lock fallback");
+    }
+    await ensurePeriodUnlocked(periodId);
+  }
+  async function ensurePeriodUnlocked(periodId) {
+    if (!periodId)
+      return;
+    const { data, error } = await requireSupabaseClient().from(TABLES.periods).select("id,is_locked").eq("id", periodId).single();
+    if (error)
+      throw error;
+    if (data.is_locked) {
+      throw new Error(`Payroll period ${periodId} is locked. Update denied.`);
+    }
+  }
+  function sanitizeUpdatePatch(patch = {}) {
+    const cleaned = {};
+    for (const [key, value] of Object.entries(patch || {})) {
+      if (value === undefined)
+        continue;
+      if (key === "id")
+        continue;
+      cleaned[key] = value;
+    }
+    return cleaned;
+  }
+  function sanitizeInsertPayload(row = {}) {
+    const cleaned = {};
+    for (const [key, value] of Object.entries(row || {})) {
+      if (value === undefined)
+        continue;
+      cleaned[key] = value;
+    }
+    return cleaned;
+  }
+  function composeCreateRow(id, patch = {}) {
+    const cleanedPatch = sanitizeInsertPayload(patch);
+    if (id == null || id === "")
+      return cleanedPatch;
+    return { id, ...cleanedPatch };
+  }
+  function applyExpectedUpdatedAt(query, expectedUpdatedAt) {
+    if (expectedUpdatedAt == null) {
+      return query.is("updated_at", null);
+    }
+    return query.eq("updated_at", expectedUpdatedAt);
+  }
+  async function updateWithOptimisticLock({ table, id, patch, expectedUpdatedAt, periodId, stateKey }) {
+    await ensurePeriodUnlockedWithRpc(periodId);
+    logWrite("update", table, { id, ...patch, expected_updated_at: expectedUpdatedAt });
+    let query = requireSupabaseClient().from(table).update({ ...sanitizeUpdatePatch(patch), updated_at: new Date().toISOString() }).eq("id", id);
+    query = applyExpectedUpdatedAt(query, expectedUpdatedAt);
+    const { data, error } = await query.select("*").maybeSingle();
+    if (error)
+      throw error;
+    if (!data) {
+      const conflict = { table, id, expectedUpdatedAt, at: new Date().toISOString() };
+      reportConflict(conflict);
+      throw new StaleWriteError("This record was updated by another user. Reloading.", conflict);
+    }
+    mergeRow(stateKey, data);
+    return data;
+  }
+  async function createRowWithLock({ table, row, periodId, stateKey }) {
+    await ensurePeriodUnlockedWithRpc(periodId);
+    logWrite("insert", table, row);
+    const payload = { ...sanitizeInsertPayload(row), updated_at: new Date().toISOString() };
+    const { data, error } = await requireSupabaseClient().from(table).insert(payload).select("*").single();
+    if (error)
+      throw error;
+    mergeRow(stateKey, data);
+    return data;
+  }
+  async function deleteWithOptimisticLock({ table, id, expectedUpdatedAt, periodId, stateKey }) {
+    await ensurePeriodUnlockedWithRpc(periodId);
+    logWrite("delete", table, { id, expected_updated_at: expectedUpdatedAt });
+    let query = requireSupabaseClient().from(table).delete().eq("id", id);
+    query = applyExpectedUpdatedAt(query, expectedUpdatedAt);
+    const { data, error } = await query.select("id").maybeSingle();
+    if (error)
+      throw error;
+    if (!data) {
+      const conflict = { table, id, expectedUpdatedAt, at: new Date().toISOString() };
+      reportConflict(conflict);
+      throw new StaleWriteError("This record was updated by another user. Reloading.", conflict);
+    }
+    return { id, table, stateKey };
+  }
+  var payrollService = {
+    tables: TABLES,
+    async debugVerifyOptimizedLoad(periodId) {
+      const tables = [
+        TABLES.dtr,
+        TABLES.loans,
+        TABLES.loanDeductions,
+        TABLES.contribFlags,
+        TABLES.punches
+      ];
+      for (const table of tables) {
+        await debugVerifyPeriodLoad(table, periodId);
+      }
+    },
+    async loadPeriods() {
+      const { data, error } = await requireSupabaseClient().from(TABLES.periods).select("*").order("period_start", { ascending: false });
+      if (error)
+        throw error;
+      data.forEach((period) => mergeRow("payrollPeriods", period));
+      return data;
+    },
+    async loadPunchesByPeriod(periodId) {
+      const { data, error } = await fetchPunchRowsByKnownShapes(periodId);
+      if (error)
+        throw error;
+      data.forEach((row) => mergeRow("dtrPunches", row));
+      return data;
+    },
+    async loadCoreReadModels({ periodId } = {}) {
+      const loaders = Object.values(TABLE_LOADERS).map(async ({ table, stateKey }) => {
+        const result = await loadRowsWithOptionalOptimizedFilter(table, periodId);
+        if (result.error)
+          throw result.error;
+        const rows = Array.isArray(result.data) ? result.data : [];
+        const coverage = getPeriodCoverage(rows, periodId);
+        let rowsToMerge = rows;
+        if (getFeatureFlag(OPTIMIZED_LOAD_FLAG, false) && periodId && coverage.hasLegacyRows) {
+          console.warn("[payroll:read:fallback] optimized filtering may omit legacy rows; using legacy in-memory filter", {
+            table,
+            periodId,
+            coverage
+          });
+          const legacy = await fetchAllRowsPaginated({ table, periodId, optimized: false });
+          if (legacy.error)
+            throw legacy.error;
+          rowsToMerge = Array.isArray(legacy.data) ? legacy.data : [];
+        }
+        rowsToMerge.forEach((row) => mergeRow(stateKey, row));
+        debugVerifyPeriodLoad(table, periodId);
+        return { table, count: rowsToMerge.length };
+      });
+      const punches = this.loadPunchesByPeriod(periodId);
+      return Promise.all([...loaders, punches]);
+    },
+    async createPunch({ periodId, employeeId, projectId, punchAt, meta = {} }) {
+      const row = {
+        payroll_period_id: periodId,
+        employee_id: employeeId,
+        project_id: projectId,
+        punch_at: punchAt,
+        meta
+      };
+      return createRowWithLock({
+        table: TABLES.punches,
+        row,
+        periodId,
+        stateKey: "dtrPunches"
+      });
+    },
+    async updatePunch(punchId, patch) {
+      const state2 = getState();
+      const existing = state2.dtrPunches.get(punchId);
+      if (!existing)
+        throw new Error(`Punch ${punchId} not found in state.`);
+      return updateWithOptimisticLock({
+        table: TABLES.punches,
+        id: punchId,
+        patch,
+        expectedUpdatedAt: existing.updated_at ?? null,
+        periodId: existing.payroll_period_id,
+        stateKey: "dtrPunches"
+      });
+    },
+    async deletePunch(punchId) {
+      const state2 = getState();
+      const existing = state2.dtrPunches.get(punchId);
+      if (!existing)
+        throw new Error(`Punch ${punchId} not found in state.`);
+      await deleteWithOptimisticLock({
+        table: TABLES.punches,
+        id: punchId,
+        expectedUpdatedAt: existing.updated_at ?? null,
+        periodId: existing.payroll_period_id,
+        stateKey: "dtrPunches"
+      });
+      removeRow("dtrPunches", punchId);
+      return { id: punchId };
+    },
+    async upsertEmployee(employeeId, patch = {}) {
+      const state2 = getState();
+      const existing = state2.employees.get(employeeId);
+      if (existing) {
+        return updateWithOptimisticLock({
+          table: TABLES.employees,
+          id: employeeId,
+          patch: sanitizeUpdatePatch(patch),
+          expectedUpdatedAt: existing.updated_at ?? null,
+          stateKey: "employees"
+        });
+      }
+      return createRowWithLock({
+        table: TABLES.employees,
+        row: composeCreateRow(employeeId, patch),
+        stateKey: "employees"
+      });
+    },
+    async upsertLoan(loanId, patch = {}) {
+      const state2 = getState();
+      const existing = state2.loans.get(loanId);
+      const periodId = patch.payroll_period_id ?? existing?.payroll_period_id ?? getState().currentPeriodId;
+      if (existing) {
+        return updateWithOptimisticLock({
+          table: TABLES.loans,
+          id: loanId,
+          patch: sanitizeUpdatePatch(patch),
+          expectedUpdatedAt: existing.updated_at ?? null,
+          periodId,
+          stateKey: "loans"
+        });
+      }
+      return createRowWithLock({
+        table: TABLES.loans,
+        row: composeCreateRow(loanId, patch),
+        periodId,
+        stateKey: "loans"
+      });
+    },
+    async upsertLoanDeduction(deductionId, patch = {}) {
+      const state2 = getState();
+      const existing = state2.loanDeductions.get(deductionId);
+      const periodId = patch.payroll_period_id ?? existing?.payroll_period_id ?? getState().currentPeriodId;
+      if (existing) {
+        return updateWithOptimisticLock({
+          table: TABLES.loanDeductions,
+          id: deductionId,
+          patch: sanitizeUpdatePatch(patch),
+          expectedUpdatedAt: existing.updated_at ?? null,
+          periodId,
+          stateKey: "loanDeductions"
+        });
+      }
+      return createRowWithLock({
+        table: TABLES.loanDeductions,
+        row: composeCreateRow(deductionId, patch),
+        periodId,
+        stateKey: "loanDeductions"
+      });
+    },
+    async upsertDtrRecord(recordId, patch = {}) {
+      const state2 = getState();
+      const existing = state2.dtrRecords.get(recordId);
+      const periodId = patch.payroll_period_id ?? existing?.payroll_period_id ?? getState().currentPeriodId;
+      if (existing) {
+        return updateWithOptimisticLock({
+          table: TABLES.dtr,
+          id: recordId,
+          patch: sanitizeUpdatePatch(patch),
+          expectedUpdatedAt: existing.updated_at ?? null,
+          periodId,
+          stateKey: "dtrRecords"
+        });
+      }
+      return createRowWithLock({
+        table: TABLES.dtr,
+        row: composeCreateRow(recordId, patch),
+        periodId,
+        stateKey: "dtrRecords"
+      });
+    },
+    async upsertProject(projectId, patch = {}) {
+      const state2 = getState();
+      const existing = state2.projects.get(projectId);
+      if (existing) {
+        return updateWithOptimisticLock({
+          table: TABLES.projects,
+          id: projectId,
+          patch: sanitizeUpdatePatch(patch),
+          expectedUpdatedAt: existing.updated_at ?? null,
+          stateKey: "projects"
+        });
+      }
+      return createRowWithLock({
+        table: TABLES.projects,
+        row: composeCreateRow(projectId, patch),
+        stateKey: "projects"
+      });
+    },
+    async upsertSchedule(scheduleId, patch = {}) {
+      const state2 = getState();
+      const existing = state2.schedules.get(scheduleId);
+      if (existing) {
+        return updateWithOptimisticLock({
+          table: TABLES.schedules,
+          id: scheduleId,
+          patch: sanitizeUpdatePatch(patch),
+          expectedUpdatedAt: existing.updated_at ?? null,
+          stateKey: "schedules"
+        });
+      }
+      return createRowWithLock({
+        table: TABLES.schedules,
+        row: composeCreateRow(scheduleId, patch),
+        stateKey: "schedules"
+      });
+    },
+    async upsertContribFlag(flagId, patch = {}) {
+      const state2 = getState();
+      const existing = state2.contribFlags.get(flagId);
+      const periodId = patch.payroll_period_id ?? existing?.payroll_period_id ?? getState().currentPeriodId;
+      if (existing) {
+        return updateWithOptimisticLock({
+          table: TABLES.contribFlags,
+          id: flagId,
+          patch: sanitizeUpdatePatch(patch),
+          expectedUpdatedAt: existing.updated_at ?? null,
+          periodId,
+          stateKey: "contribFlags"
+        });
+      }
+      return createRowWithLock({
+        table: TABLES.contribFlags,
+        row: composeCreateRow(flagId, patch),
+        periodId,
+        stateKey: "contribFlags"
+      });
+    },
+    async deleteDtrRecord(recordId) {
+      const state2 = getState();
+      const existing = state2.dtrRecords.get(recordId);
+      if (!existing)
+        throw new Error(`DTR record ${recordId} not found in state.`);
+      await deleteWithOptimisticLock({
+        table: TABLES.dtr,
+        id: recordId,
+        expectedUpdatedAt: existing.updated_at ?? null,
+        periodId: existing.payroll_period_id,
+        stateKey: "dtrRecords"
+      });
+      removeRow("dtrRecords", recordId);
+      return { id: recordId };
+    },
+    async deleteLoanDeduction(deductionId) {
+      const state2 = getState();
+      const existing = state2.loanDeductions.get(deductionId);
+      if (!existing)
+        throw new Error(`Loan deduction ${deductionId} not found in state.`);
+      await deleteWithOptimisticLock({
+        table: TABLES.loanDeductions,
+        id: deductionId,
+        expectedUpdatedAt: existing.updated_at ?? null,
+        periodId: existing.payroll_period_id,
+        stateKey: "loanDeductions"
+      });
+      removeRow("loanDeductions", deductionId);
+      return { id: deductionId };
+    },
+    async deleteLoan(loanId) {
+      const state2 = getState();
+      const existing = state2.loans.get(loanId);
+      if (!existing)
+        throw new Error(`Loan ${loanId} not found in state.`);
+      await deleteWithOptimisticLock({
+        table: TABLES.loans,
+        id: loanId,
+        expectedUpdatedAt: existing.updated_at ?? null,
+        periodId: existing.payroll_period_id,
+        stateKey: "loans"
+      });
+      removeRow("loans", loanId);
+      return { id: loanId };
+    },
+    async deleteContribFlag(flagId) {
+      const state2 = getState();
+      const existing = state2.contribFlags.get(flagId);
+      if (!existing)
+        throw new Error(`Contribution flag ${flagId} not found in state.`);
+      await deleteWithOptimisticLock({
+        table: TABLES.contribFlags,
+        id: flagId,
+        expectedUpdatedAt: existing.updated_at ?? null,
+        periodId: existing.payroll_period_id,
+        stateKey: "contribFlags"
+      });
+      removeRow("contribFlags", flagId);
+      return { id: flagId };
+    },
+    async setPeriodLock(periodId, isLocked) {
+      const patch = { is_locked: !!isLocked, updated_at: new Date().toISOString() };
+      logWrite("update", TABLES.periods, { id: periodId, ...patch });
+      const { data, error } = await requireSupabaseClient().from(TABLES.periods).update(patch).eq("id", periodId).select("*").single();
+      if (error)
+        throw error;
+      mergeRow("payrollPeriods", data);
+      return data;
+    },
+    async saveSnapshot(snapshot) {
+      const { payroll_period_id: periodId } = snapshot;
+      await ensurePeriodUnlockedWithRpc(periodId);
+      logWrite("insert", TABLES.snapshots, snapshot);
+      const { data, error } = await requireSupabaseClient().from(TABLES.snapshots).insert({ ...sanitizeInsertPayload(snapshot), created_at: new Date().toISOString() }).select("*").single();
+      if (error)
+        throw error;
+      mergeRow("payrollSnapshots", data);
+      return data;
+    },
+    async updateSnapshot() {
+      throw new Error("Snapshots are immutable. Create a new snapshot row instead.");
+    }
+  };
+
+  // src/realtime/subscriptions.js
+  var TABLE_TO_STATE_KEY = {
+    payroll_periods: "payrollPeriods",
+    payroll_period_snapshots: "payrollSnapshots",
+    pp_dtr_records: "dtrRecords",
+    dtr_punches: "dtrPunches",
+    pp_employees: "employees",
+    pp_projects: "projects",
+    pp_schedules: "schedules",
+    employee_loans: "loans",
+    loan_deductions: "loanDeductions",
+    pp_contrib_flags: "contribFlags",
+    profiles: "profiles"
+  };
+  var GROUP_TABLES = {
+    payroll_core: ["payroll_periods", "payroll_period_snapshots", "pp_employees", "pp_projects", "pp_schedules"],
+    dtr_live: ["dtr_punches", "pp_dtr_records"]
+  };
+  var OPTIONAL_MODULE_TABLES = {
+    loans: ["employee_loans", "loan_deductions"],
+    contrib_flags: ["pp_contrib_flags"],
+    profiles: ["profiles"],
+    dtr_records_legacy: ["pp_dtr_records"]
+  };
+  var PERIOD_SCOPED_TABLES = new Set([
+    "payroll_period_snapshots",
+    "pp_dtr_records",
+    "dtr_punches",
+    "employee_loans",
+    "loan_deductions",
+    "pp_contrib_flags"
+  ]);
+  var DTR_LIVE_TABLES = new Set(GROUP_TABLES.dtr_live);
+  var DEBUG_REALTIME_FLAG = "DEBUG_REALTIME";
+  var REALTIME_FLUSH_MS = 120;
+  var mutationQueue = [];
+  var flushTimer = null;
+  var latestActiveEvent = null;
+  var manager = null;
+  function logRealtimeDebug(message, details = undefined) {
+    if (!getFeatureFlag(DEBUG_REALTIME_FLAG, false))
+      return;
+    if (details === undefined) {
+      console.info(`[payroll:realtime:debug] ${message}`);
+      return;
+    }
+    console.info(`[payroll:realtime:debug] ${message}`, details);
+  }
+  function getEventPeriodInfo(payload) {
+    const currentPeriodId = getState().currentPeriodId;
+    const newPeriodId = payload?.new?.payroll_period_id ?? null;
+    const oldPeriodId = payload?.old?.payroll_period_id ?? null;
+    const hasPeriodId = newPeriodId != null || oldPeriodId != null;
+    return { currentPeriodId, newPeriodId, oldPeriodId, hasPeriodId };
+  }
+  function isEventForCurrentPeriod(table, payload) {
+    if (!PERIOD_SCOPED_TABLES.has(table))
+      return true;
+    const info = getEventPeriodInfo(payload);
+    if (!info.currentPeriodId)
+      return true;
+    if (!info.hasPeriodId) {
+      logRealtimeDebug("applied legacy row without payroll_period_id", { table, eventType: payload?.eventType });
+      return true;
+    }
+    return info.newPeriodId === info.currentPeriodId || info.oldPeriodId === info.currentPeriodId;
+  }
+  function isQueuedEntryStillRelevant(entry) {
+    if (!PERIOD_SCOPED_TABLES.has(entry.table))
+      return true;
+    const currentPeriodId = getState().currentPeriodId;
+    if (!currentPeriodId)
+      return true;
+    if (entry.isLegacyPeriodRow)
+      return true;
+    return entry.newPeriodId === currentPeriodId || entry.oldPeriodId === currentPeriodId;
+  }
+  function getEntryDedupeKey(entry) {
+    const id = entry.id ?? entry.row?.id;
+    return id == null ? null : `${entry.stateKey}:${id}`;
+  }
+  function refreshDiagnostics() {
+    if (!manager)
+      return;
+    setRealtimeDiagnostics({
+      activeChannelCount: manager.channelsByTable.size,
+      activeRealtimeGroups: [...manager.activeGroups],
+      activeRealtimeTables: [...manager.channelsByTable.keys()],
+      degradedModeEnabled: !!manager.degradedModeEnabled
+    });
+  }
+  function flushMutations() {
+    flushTimer = null;
+    const pending = mutationQueue.splice(0, mutationQueue.length);
+    if (!pending.length)
+      return;
+    const deduped = [];
+    const dedupeIndex = new Map;
+    for (const entry of pending) {
+      const key = getEntryDedupeKey(entry);
+      if (!key) {
+        deduped.push(entry);
+        continue;
+      }
+      const existingIndex = dedupeIndex.get(key);
+      if (existingIndex == null) {
+        dedupeIndex.set(key, deduped.length);
+        deduped.push(entry);
+        continue;
+      }
+      deduped[existingIndex] = entry;
+    }
+    let applied = 0;
+    let ignoredAfterDebounce = 0;
+    batch(() => {
+      for (const entry of deduped) {
+        if (!isQueuedEntryStillRelevant(entry)) {
+          ignoredAfterDebounce += 1;
+          continue;
+        }
+        if (entry.kind === "delete") {
+          removeRow(entry.stateKey, entry.id);
+        } else {
+          mergeRow(entry.stateKey, entry.row);
+        }
+        applied += 1;
+      }
+      if (applied > 0 && latestActiveEvent) {
+        setLastRealtimeEvent(latestActiveEvent);
+      }
+    });
+    latestActiveEvent = null;
+    if (deduped.length > 1 || ignoredAfterDebounce > 0) {
+      logRealtimeDebug("batched realtime mutations flushed", {
+        queued: pending.length,
+        deduped: deduped.length,
+        applied,
+        ignoredAfterDebounce
+      });
+    }
+  }
+  function scheduleFlush() {
+    if (flushTimer)
+      return;
+    flushTimer = window.setTimeout(flushMutations, REALTIME_FLUSH_MS);
+  }
+  function enqueueMutation(entry) {
+    mutationQueue.push(entry);
+    scheduleFlush();
+  }
+  function handleChange(table, payload) {
+    const event = {
+      table,
+      type: payload.eventType,
+      timestamp: new Date().toISOString()
+    };
+    const stateKey = TABLE_TO_STATE_KEY[table];
+    if (!stateKey)
+      return;
+    if (manager?.dtrLiveSuspended && DTR_LIVE_TABLES.has(table))
+      return;
+    if (!isEventForCurrentPeriod(table, payload)) {
+      const periodInfo2 = getEventPeriodInfo(payload);
+      logRealtimeDebug("ignored event for non-active period", {
+        table,
+        eventType: payload?.eventType,
+        currentPeriodId: periodInfo2.currentPeriodId,
+        newPeriodId: periodInfo2.newPeriodId,
+        oldPeriodId: periodInfo2.oldPeriodId
+      });
+      return;
+    }
+    latestActiveEvent = event;
+    incrementRealtimeTableEvent(table);
+    const periodInfo = getEventPeriodInfo(payload);
+    logRealtimeDebug("queued event for active period", {
+      table,
+      eventType: payload?.eventType,
+      currentPeriodId: periodInfo.currentPeriodId,
+      newPeriodId: periodInfo.newPeriodId,
+      oldPeriodId: periodInfo.oldPeriodId
+    });
+    const queueEntry = {
+      table,
+      stateKey,
+      newPeriodId: periodInfo.newPeriodId,
+      oldPeriodId: periodInfo.oldPeriodId,
+      isLegacyPeriodRow: PERIOD_SCOPED_TABLES.has(table) && !periodInfo.hasPeriodId
+    };
+    if (payload.eventType === "DELETE") {
+      enqueueMutation({ ...queueEntry, kind: "delete", id: payload.old?.id });
+      return;
+    }
+    enqueueMutation({ ...queueEntry, kind: "merge", row: payload.new, id: payload.new?.id });
+  }
+  function subscribeTables(tables, groupName) {
+    if (!manager?.supabase)
+      return;
+    for (const table of tables) {
+      if (manager.channelsByTable.has(table))
+        continue;
+      const channel = manager.supabase.channel(`rt:${groupName}:${table}`).on("postgres_changes", { event: "*", schema: "public", table }, (payload) => handleChange(table, payload)).subscribe((status) => {
+        setRealtimeStatus(status);
+      });
+      manager.channelsByTable.set(table, channel);
+      manager.groupTables.set(groupName, new Set([...manager.groupTables.get(groupName) || new Set, table]));
+    }
+    manager.activeGroups.add(groupName);
+    refreshDiagnostics();
+  }
+  function unsubscribeGroup(groupName) {
+    if (!manager?.supabase)
+      return;
+    const tables = manager.groupTables.get(groupName);
+    if (!tables?.size) {
+      manager.activeGroups.delete(groupName);
+      refreshDiagnostics();
+      return;
+    }
+    for (const table of tables) {
+      const channel = manager.channelsByTable.get(table);
+      if (channel)
+        manager.supabase.removeChannel(channel);
+      manager.channelsByTable.delete(table);
+    }
+    manager.groupTables.delete(groupName);
+    manager.activeGroups.delete(groupName);
+    if (!manager.channelsByTable.size)
+      setRealtimeStatus("idle");
+    refreshDiagnostics();
+  }
+  function initRealtimeManager() {
+    if (manager)
+      return manager;
+    const supabase = getSupabaseClient();
+    if (!supabase) {
+      setRealtimeStatus("degraded");
+      setRealtimeDiagnostics({ degradedModeEnabled: true });
+      manager = {
+        supabase: null,
+        channelsByTable: new Map,
+        groupTables: new Map,
+        activeGroups: new Set,
+        dtrLiveSuspended: false,
+        dtrWasActiveBeforeSuspend: false,
+        degradedModeEnabled: true
+      };
+      return manager;
+    }
+    setRealtimeStatus("ready");
+    manager = {
+      supabase,
+      channelsByTable: new Map,
+      groupTables: new Map,
+      activeGroups: new Set,
+      dtrLiveSuspended: false,
+      dtrWasActiveBeforeSuspend: false,
+      degradedModeEnabled: false
+    };
+    refreshDiagnostics();
+    return manager;
+  }
+  function subscribePayrollCore({ periodId } = {}) {
+    if (!manager)
+      initRealtimeManager();
+    subscribeTables(GROUP_TABLES.payroll_core, "payroll_core");
+  }
+  function subscribeDtrLive({ periodId } = {}) {
+    if (!manager)
+      initRealtimeManager();
+    manager.dtrLiveSuspended = false;
+    subscribeTables(GROUP_TABLES.dtr_live, "dtr_live");
+  }
+  function unsubscribeDtrLive() {
+    if (!manager)
+      return;
+    manager.dtrWasActiveBeforeSuspend = false;
+    manager.dtrLiveSuspended = false;
+    unsubscribeGroup("dtr_live");
+  }
+  function suspendDtrLive() {
+    if (!manager)
+      return;
+    manager.dtrWasActiveBeforeSuspend = manager.activeGroups.has("dtr_live");
+    manager.dtrLiveSuspended = true;
+    if (manager.dtrWasActiveBeforeSuspend) {
+      unsubscribeGroup("dtr_live");
+    }
+  }
+  function resumeDtrLive({ periodId } = {}) {
+    if (!manager)
+      initRealtimeManager();
+    if (!manager)
+      return;
+    const shouldResume = manager.dtrLiveSuspended && manager.dtrWasActiveBeforeSuspend;
+    manager.dtrLiveSuspended = false;
+    if (shouldResume) {
+      subscribeTables(GROUP_TABLES.dtr_live, "dtr_live");
+    }
+  }
+  function subscribeOptionalModule(moduleName) {
+    if (!manager)
+      initRealtimeManager();
+    const tables = OPTIONAL_MODULE_TABLES[moduleName];
+    if (!tables?.length)
+      return;
+    subscribeTables(tables, `optional:${moduleName}`);
+  }
+  function unsubscribeOptionalModule(moduleName) {
+    if (!manager)
+      return;
+    unsubscribeGroup(`optional:${moduleName}`);
+  }
+  function isDtrLiveActive() {
+    return !!manager?.activeGroups?.has("dtr_live");
+  }
+  function destroyRealtimeManager() {
+    if (!manager)
+      return;
+    if (flushTimer) {
+      window.clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+    mutationQueue.splice(0, mutationQueue.length);
+    for (const groupName of [...manager.groupTables.keys()]) {
+      unsubscribeGroup(groupName);
+    }
+    setRealtimeStatus("closed");
+    setRealtimeDiagnostics({
+      activeChannelCount: 0,
+      activeRealtimeGroups: [],
+      activeRealtimeTables: []
+    });
+    manager = null;
+  }
+
+  // src/ui/payrollController.js
+  var LOCKABLE_SELECTOR = "input, select, textarea, button";
+  function renderPeriodLockStatus(root, period) {
+    const lockEl = root.querySelector("[data-payroll-lock-state]");
+    if (!lockEl)
+      return;
+    const diagnostics = getState().diagnostics || {};
+    const pending = diagnostics.periodBootstrapPending || diagnostics.periodSwitchInFlight;
+    const lockKnown = !!period && typeof period.is_locked === "boolean";
+    if (pending || !lockKnown) {
+      lockEl.textContent = "Resolving…";
+      lockEl.dataset.locked = "pending";
+      return;
+    }
+    lockEl.textContent = period.is_locked ? "Locked" : "Open";
+    lockEl.dataset.locked = period?.is_locked ? "true" : "false";
+  }
+  function renderPunchCount(root) {
+    const countEl = root.querySelector("[data-punch-count]");
+    if (!countEl)
+      return;
+    countEl.textContent = String(getState().dtrPunches.size);
+  }
+  function renderConflictBanner(root) {
+    const state2 = getState();
+    const banner = root.querySelector("[data-payroll-conflict-banner]");
+    if (!banner)
+      return;
+    const conflict = state2.diagnostics.lastConflict;
+    if (!conflict) {
+      banner.hidden = true;
+      return;
+    }
+    const message = banner.querySelector("[data-payroll-conflict-message]");
+    if (message) {
+      message.textContent = "This record was updated by another user. Reloading latest row data.";
+    }
+    banner.hidden = false;
+  }
+  function applyLockedRule(el, isLocked) {
+    if (el.dataset.payrollHealthToggle === "true" || el.closest("[data-payroll-health-panel]"))
+      return;
+    if (el.dataset.allowWhenLocked === "true")
+      return;
+    if (isLocked) {
+      el.dataset.lockedDisabled = el.disabled ? "already" : "managed";
+      if (!el.disabled)
+        el.disabled = true;
+      return;
+    }
+    if (el.dataset.lockedDisabled === "managed") {
+      el.disabled = false;
+    }
+    delete el.dataset.lockedDisabled;
+  }
+  function renderLockedInputState(root, period) {
+    const diagnostics = getState().diagnostics || {};
+    const lockKnown = !!period && typeof period.is_locked === "boolean";
+    const forceLocked = diagnostics.periodBootstrapPending || diagnostics.periodSwitchInFlight || !lockKnown;
+    const isLocked = forceLocked ? true : !!period.is_locked;
+    const wrapper = root.querySelector("#payrollWrapper");
+    if (!wrapper)
+      return;
+    wrapper.querySelectorAll(LOCKABLE_SELECTOR).forEach((el) => applyLockedRule(el, isLocked));
+  }
+  function renderDiagnostics(root) {
+    const state2 = getState();
+    const diag = state2.diagnostics;
+    const period = state2.currentPeriodId ? state2.payrollPeriods.get(state2.currentPeriodId) : null;
+    const connected = root.querySelector("[data-health-supabase]");
+    if (connected)
+      connected.textContent = diag.supabaseConnected === null ? "Unknown" : diag.supabaseConnected ? "Connected" : "Disconnected";
+    const rt = root.querySelector("[data-health-realtime]");
+    if (rt)
+      rt.textContent = diag.realtimeStatus || "idle";
+    const periodEl = root.querySelector("[data-health-period]");
+    if (periodEl)
+      periodEl.textContent = state2.currentPeriodId || "None";
+    const lockedEl = root.querySelector("[data-health-locked]");
+    if (lockedEl)
+      lockedEl.textContent = period ? period.is_locked ? "Yes" : "No" : "Unknown";
+    const lastEventEl = root.querySelector("[data-health-last-event]");
+    if (lastEventEl) {
+      if (!diag.lastRealtimeEvent) {
+        lastEventEl.textContent = "None";
+      } else {
+        const evt = diag.lastRealtimeEvent;
+        lastEventEl.textContent = `${evt.type} ${evt.table} @ ${evt.timestamp}`;
+      }
+    }
+  }
+  function ensureDiagnosticsPanel(root) {
+    if (root.querySelector("[data-payroll-health-panel]"))
+      return;
+    const wrapper = root.querySelector("#payrollWrapper") || root;
+    const anchor = wrapper.querySelector("header");
+    const container = document.createElement("div");
+    container.dataset.payrollHealthContainer = "true";
+    container.style.margin = "8px 0 10px";
+    const conflictBanner = document.createElement("div");
+    conflictBanner.dataset.payrollConflictBanner = "true";
+    conflictBanner.hidden = true;
+    conflictBanner.style.marginBottom = "8px";
+    conflictBanner.style.padding = "8px";
+    conflictBanner.style.border = "1px solid #f59e0b";
+    conflictBanner.style.borderRadius = "8px";
+    conflictBanner.style.fontSize = "12px";
+    conflictBanner.style.background = "rgba(245,158,11,0.1)";
+    conflictBanner.innerHTML = `
+    <span data-payroll-conflict-message></span>
+    <button type="button" class="bp-btn" data-payroll-conflict-dismiss style="margin-left:8px">Dismiss</button>
+  `;
+    const toggle = document.createElement("button");
+    toggle.type = "button";
+    toggle.className = "bp-btn";
+    toggle.dataset.payrollHealthToggle = "true";
+    toggle.textContent = "Health";
+    const panel = document.createElement("div");
+    panel.dataset.payrollHealthPanel = "true";
+    panel.hidden = true;
+    panel.style.marginTop = "8px";
+    panel.style.padding = "8px";
+    panel.style.border = "1px solid var(--bp-border, #2e3747)";
+    panel.style.borderRadius = "8px";
+    panel.style.fontSize = "12px";
+    panel.innerHTML = `
+    <div>Supabase: <strong data-health-supabase>Unknown</strong></div>
+    <div>Realtime: <strong data-health-realtime>idle</strong></div>
+    <div>Active Period: <strong data-health-period>None</strong></div>
+    <div>Locked: <strong data-health-locked>Unknown</strong></div>
+    <div>Last Event: <strong data-health-last-event>None</strong></div>
+  `;
+    toggle.addEventListener("click", () => {
+      panel.hidden = !panel.hidden;
+    });
+    conflictBanner.querySelector("[data-payroll-conflict-dismiss]")?.addEventListener("click", () => {
+      clearConflict();
+    });
+    container.appendChild(conflictBanner);
+    container.appendChild(toggle);
+    container.appendChild(panel);
+    if (anchor && anchor.parentNode) {
+      anchor.insertAdjacentElement("afterend", container);
+    } else {
+      wrapper.prepend(container);
+    }
+  }
+  function mountPayrollController(root) {
+    let lastLockKey = null;
+    let lockObserver = null;
+    function refreshLockObserver(isLocked) {
+      if (lockObserver) {
+        lockObserver.disconnect();
+        lockObserver = null;
+      }
+      if (!isLocked)
+        return;
+      const wrapper = root.querySelector("#payrollWrapper");
+      if (!wrapper)
+        return;
+      lockObserver = new MutationObserver((mutations) => {
+        for (const m of mutations) {
+          for (const node of m.addedNodes || []) {
+            if (!(node instanceof Element))
+              continue;
+            if (node.matches(LOCKABLE_SELECTOR)) {
+              applyLockedRule(node, true);
+            }
+            node.querySelectorAll?.(LOCKABLE_SELECTOR).forEach((el) => applyLockedRule(el, true));
+          }
+        }
+      });
+      lockObserver.observe(wrapper, { childList: true, subtree: true });
+    }
+    const render = (state2, change) => {
+      ensureDiagnosticsPanel(root);
+      const currentState = getState();
+      const period = currentState.currentPeriodId ? currentState.payrollPeriods.get(currentState.currentPeriodId) : null;
+      const diagnostics = currentState.diagnostics || {};
+      const lockKnown = !!period && typeof period.is_locked === "boolean";
+      const forceLocked = diagnostics.periodBootstrapPending || diagnostics.periodSwitchInFlight || !lockKnown;
+      const isLocked = forceLocked ? true : !!period.is_locked;
+      const phaseKey = diagnostics.periodBootstrapPending ? "bootstrap" : diagnostics.periodSwitchInFlight ? "switch" : "steady";
+      const lockKey = `${currentState.currentPeriodId || ""}:${phaseKey}:${lockKnown ? isLocked ? "1" : "0" : "u"}`;
+      renderPeriodLockStatus(root, period);
+      renderPunchCount(root);
+      renderDiagnostics(root);
+      renderConflictBanner(root);
+      if (lockKey !== lastLockKey) {
+        renderLockedInputState(root, period);
+        refreshLockObserver(lockKnown && isLocked);
+        lastLockKey = lockKey;
+      }
+    };
+    render();
+    const unsub = subscribe(render);
+    return () => {
+      if (lockObserver)
+        lockObserver.disconnect();
+      lockObserver = null;
+      unsub();
+    };
+  }
+
+  // src/main.js
+  var cleanupUi = null;
+  var bootstrapped = false;
+  var periodSwitchQueue = Promise.resolve();
+  var CRITICAL_LOCAL_KEYS = new Set([
+    "att_employees_v2",
+    "att_projects_v1",
+    "att_schedules_v2",
+    "att_schedules_default",
+    "att_records_v2",
+    "payroll_loan_tracker",
+    "payroll_loan_sss",
+    "payroll_loan_pagibig",
+    "payroll_vale",
+    "payroll_vale_wed",
+    "payroll_contrib_flags",
+    "payroll_lock_state",
+    "payroll_rates",
+    "payroll_hist",
+    "payroll_other_deductions_details",
+    "payroll_other_deductions_total",
+    "payroll_additional_income_details",
+    "payroll_additional_income_total"
+  ]);
+  function deprecateCriticalLocalAuthority() {
+    if (window.__payrollLocalAuthorityDeprecated)
+      return;
+    window.__payrollLocalAuthorityDeprecated = true;
+    const warnedKeys = new Set;
+    const debugDeprecation = !!window.__PAYROLL_DEBUG_DEPRECATION;
+    const requestedStrictDeprecation = !!window.__PAYROLL_STRICT_LOCAL_DEPRECATION;
+    const isLocalDev = ["localhost", "127.0.0.1"].includes(window.location?.hostname || "");
+    const strictDeprecation = requestedStrictDeprecation && isLocalDev;
+    if (requestedStrictDeprecation && !isLocalDev) {
+      console.warn("[payroll:deprecation] strict local authority blocking is ignored outside local dev hosts");
+    }
+    const warnOnce = (kind, key) => {
+      if (!debugDeprecation)
+        return;
+      const marker = `${kind}:${key}`;
+      if (warnedKeys.has(marker))
+        return;
+      warnedKeys.add(marker);
+      console.warn(`[payroll:deprecation] ${kind} for critical key`, key);
+    };
+    const originalReadKv = window.readKV;
+    if (typeof originalReadKv === "function") {
+      window.readKV = async (key, fallback) => {
+        if (CRITICAL_LOCAL_KEYS.has(key)) {
+          warnOnce("KV read observed (legacy fallback candidate)", key);
+        }
+        return originalReadKv(key, fallback);
+      };
+    }
+    const originalWriteKv = window.writeKV;
+    if (typeof originalWriteKv === "function") {
+      window.writeKV = async (key, value) => {
+        if (CRITICAL_LOCAL_KEYS.has(key)) {
+          warnOnce("KV write observed (allowed for compatibility)", key);
+          if (strictDeprecation) {
+            throw new Error(`[payroll:deprecation] blocked critical KV write for ${key}`);
+          }
+        }
+        return originalWriteKv(key, value);
+      };
+    }
+    try {
+      const originalGetItem = window.localStorage.getItem.bind(window.localStorage);
+      window.localStorage.getItem = (key) => {
+        if (CRITICAL_LOCAL_KEYS.has(key)) {
+          warnOnce("localStorage read observed (legacy fallback candidate)", key);
+        }
+        return originalGetItem(key);
+      };
+      const originalSetItem = window.localStorage.setItem.bind(window.localStorage);
+      window.localStorage.setItem = (key, value) => {
+        if (CRITICAL_LOCAL_KEYS.has(key)) {
+          warnOnce("localStorage write observed", key);
+          if (strictDeprecation) {
+            throw new Error(`[payroll:deprecation] blocked critical localStorage write for ${key}`);
+          }
+        }
+        return originalSetItem(key, value);
+      };
+    } catch (error) {
+      console.warn("localStorage interception failed", error);
+    }
+  }
+  async function bootstrapPayrollApp() {
+    if (bootstrapped)
+      return;
+    bootstrapped = true;
+    deprecateCriticalLocalAuthority();
+    setPeriodBootstrapPending(true);
+    clearPeriodSwitchError();
+    try {
+      const supabase = await waitForSupabaseClient({ timeoutMs: 8000, intervalMs: 80 });
+      if (!supabase) {
+        setSupabaseConnected(false);
+        console.error("Payroll bootstrap failed: Supabase client not available on window.supabase.");
+        return;
+      }
+      try {
+        const { error } = await supabase.from("payroll_periods").select("id").limit(1);
+        setSupabaseConnected(!error);
+        if (error)
+          console.warn("Supabase connectivity check failed", error);
+      } catch (error) {
+        setSupabaseConnected(false);
+        console.warn("Supabase connectivity check failed", error);
+      }
+      let currentPeriodId = null;
+      try {
+        const periods = await payrollService.loadPeriods();
+        if (periods.length) {
+          currentPeriodId = periods[0].id;
+          setCurrentPeriod(currentPeriodId);
+          window.currentPeriodId = currentPeriodId;
+        }
+      } catch (error) {
+        console.error("Payroll periods load failed", error);
+      }
+      try {
+        await payrollService.loadCoreReadModels({ periodId: currentPeriodId });
+      } catch (error) {
+        console.error("Payroll core read models load failed", error);
+      }
+      window.payrollService = payrollService;
+      const root = document.getElementById("panelPayroll") || document.body;
+      cleanupUi = mountPayrollController(root);
+      window.__PAYROLL_MODULAR_LOCK_ACTIVE = true;
+      window.getPayrollPeriodLockState = (periodId = getState().currentPeriodId) => {
+        if (!periodId)
+          return null;
+        const period = getState().payrollPeriods.get(periodId);
+        return period && typeof period.is_locked === "boolean" ? !!period.is_locked : null;
+      };
+      const PERIOD_SCOPED_TABLES2 = ["dtrRecords", "dtrPunches", "loans", "loanDeductions", "contribFlags"];
+      const snapshotTables = (tableKeys) => {
+        const state2 = getState();
+        return tableKeys.reduce((acc, key) => {
+          const source = state2[key] instanceof Map ? state2[key] : new Map;
+          acc[key] = new Map(source);
+          return acc;
+        }, {});
+      };
+      const restoreTables = (snapshot, tableKeys) => {
+        tableKeys.forEach((tableKey) => {
+          resetTable(tableKey);
+          const rows = snapshot?.[tableKey] || new Map;
+          rows.forEach((row) => mergeRow(tableKey, row));
+        });
+      };
+      const applyPeriodSwitch = async (nextPeriodId) => {
+        if (!nextPeriodId)
+          return;
+        if (nextPeriodId === getState().currentPeriodId)
+          return;
+        const previousPeriodId = getState().currentPeriodId;
+        const previousTables = snapshotTables(PERIOD_SCOPED_TABLES2);
+        setPeriodSwitchInFlight(true);
+        clearPeriodSwitchError();
+        try {
+          PERIOD_SCOPED_TABLES2.forEach((tableKey) => resetTable(tableKey));
+          setCurrentPeriod(nextPeriodId);
+          await payrollService.loadCoreReadModels({ periodId: nextPeriodId });
+          subscribePayrollCore({ periodId: nextPeriodId });
+          currentPeriodId = nextPeriodId;
+          window.currentPeriodId = nextPeriodId;
+        } catch (error) {
+          console.error("Payroll period switch failed", error);
+          setPeriodSwitchError(error?.message || "Period switch failed");
+          restoreTables(previousTables, PERIOD_SCOPED_TABLES2);
+          setCurrentPeriod(previousPeriodId);
+          window.currentPeriodId = previousPeriodId || null;
+          if (previousPeriodId) {
+            subscribePayrollCore({ periodId: previousPeriodId });
+          }
+        } finally {
+          setPeriodSwitchInFlight(false);
+        }
+      };
+      const queuePeriodSwitch = (nextPeriodId) => {
+        periodSwitchQueue = periodSwitchQueue.catch(() => {
+          return;
+        }).then(() => applyPeriodSwitch(nextPeriodId));
+        return periodSwitchQueue;
+      };
+      const resolvePeriodIdFromRange = (start, end) => {
+        if (!start || !end)
+          return null;
+        for (const period of getState().payrollPeriods.values()) {
+          if (period?.period_start === start && period?.period_end === end)
+            return period.id;
+        }
+        return null;
+      };
+      const resolvePeriodIdFromSelect = (selectEl) => {
+        if (!selectEl)
+          return null;
+        const selected = selectEl.options?.[selectEl.selectedIndex] || null;
+        const dataPeriodId = selected?.dataset?.periodId || "";
+        if (dataPeriodId)
+          return dataPeriodId;
+        const rawValue = String(selected?.value ?? selectEl.value ?? "").trim();
+        if (rawValue && getState().payrollPeriods.has(rawValue))
+          return rawValue;
+        if (rawValue.includes("|")) {
+          const [start, end] = rawValue.split("|");
+          const fromRange = resolvePeriodIdFromRange(start, end);
+          if (fromRange)
+            return fromRange;
+        }
+        const weekStart = document.getElementById("weekStart")?.value || "";
+        const weekEnd = document.getElementById("weekEnd")?.value || "";
+        return resolvePeriodIdFromRange(weekStart, weekEnd);
+      };
+      const onPeriodPickerChange = (event) => {
+        const selectedPeriodId = resolvePeriodIdFromSelect(event?.target);
+        if (!selectedPeriodId || selectedPeriodId === currentPeriodId)
+          return;
+        queuePeriodSwitch(selectedPeriodId);
+      };
+      document.getElementById("activePayrollSelect")?.addEventListener("change", onPeriodPickerChange);
+      document.getElementById("bpActivePayrollSelect")?.addEventListener("change", onPeriodPickerChange);
+      window.payrollDebugVerify = async (periodId = currentPeriodId) => {
+        if (!periodId) {
+          console.warn("[payroll:verify] no payroll period selected");
+          return;
+        }
+        await payrollService.debugVerifyOptimizedLoad(periodId);
+      };
+      try {
+        initRealtimeManager();
+        window.__DISABLE_LEGACY_DTR_SUBSCRIPTIONS = false;
+        if (window.__ENABLE_DTR_LIVE_REALTIME == null)
+          window.__ENABLE_DTR_LIVE_REALTIME = false;
+        subscribePayrollCore({ periodId: currentPeriodId });
+        window.payrollRealtimeManager = {
+          subscribePayrollCore,
+          subscribeDtrLive,
+          unsubscribeDtrLive,
+          suspendDtrLive,
+          resumeDtrLive,
+          subscribeOptionalModule,
+          unsubscribeOptionalModule,
+          isDtrLiveActive
+        };
+      } catch (error) {
+        console.error("Realtime bootstrap failed", error);
+      }
+      window.addEventListener("beforeunload", () => {
+        if (typeof cleanupUi === "function")
+          cleanupUi();
+        destroyRealtimeManager();
+      });
+    } finally {
+      setPeriodBootstrapPending(false);
+    }
+  }
+  try {
+    deprecateCriticalLocalAuthority();
+  } catch (error) {
+    console.warn("initial localStorage deprecation hook failed", error);
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", bootstrapPayrollApp);
+  } else {
+    bootstrapPayrollApp().catch((error) => {
+      console.error("Payroll bootstrap failed", error);
+    });
+  }
+})();
+
+</script>
 
 </html>


### PR DESCRIPTION
### Motivation
- Consolidate and modernize legacy client scripts by inlining key modules to reduce extra network requests and enable tighter bootstrapping with a Supabase client.
- Provide a unified shared key-value storage backed by Supabase for multi-device sync and robust conflict handling for critical payroll data.
- Replace external legacy script files with self-contained implementations for performance tweaks, dashboard backup/restore, audit inspection, and realtime/payroll application logic.

### Description
- Replaced `<script src="./src/legacy/...">` imports with inline scripts: `bpSafeDomHelpers`, performance tweaks, a Supabase-backed KV sync adapter, dashboard `backupRestore` logic, `auditTab` UI, and the consolidated `main` module code; removed the corresponding external script includes.
- Bootstrapped a Supabase client (`createClient`) using `window.SUPABASE_URL`/`window.SUPABASE_KEY` defaults and exposed `window.supabase` and helper globals for the app.
- Implemented a `sharedGet`/`sharedSet` KV adapter that normalizes/unwraps values, maintains `__meta` for conflict resolution, queues pending writes while offline, flushes pending writes on `online`, and patches `localStorage.setItem`/`removeItem` to route shared keys through the adapter.
- Added performance improvements that lazy-load offscreen `img`/`iframe` elements and set `decoding=async` when missing, applied on DOM ready.
- Implemented dashboard Full Backup & Restore inline logic that builds a backup bundle (localStorage + KV + DTR rows), supports local download and optional Supabase storage upload, and provides file-based restore applying localStorage, KV upserts, and DTR upserts.
- Inlined and reorganized core application modules: feature-flag helpers, structured application `state` store and subscription system, `payrollService` with optimistic-locking and RPC guard, realtime subscription manager with batched mutation application and diagnostics, and a `payrollController` UI binder that enforces lockable input behavior and conflict banners.
- Added utilities for audit snapshot browsing and verification (`audit` UI), snapshot segment rendering, and hash verification hooks that call `window.readSnapshotIndex` / `window.readSnapshotSegment` / `window.verifyAuditManifestForPeriod` when available.
- Preserved runtime feature toggles, deprecation hooks for critical local authority with optional strict blocking, and compatibility fallbacks (legacy table shapes, legacy DTR layout) in data loaders.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc310c826483289822f0f25735179a)