### PR TITLE
Add Print button to Adjustments tab for employees with adjustment values

### DIFF
--- a/index.html
+++ b/index.html
@@ -3377,6 +3377,7 @@ window.addEventListener('load', dashReports);
         <th>Type</th>
         <th>REG Adj Hrs</th>
         <th>ADJ OT Hrs</th>
+        <th>Print</th>
        </tr>
       </thead>
       <tbody></tbody>
@@ -9247,7 +9248,15 @@ function renderAdjustmentHoursTable(){
       <td class="adjTypeCell"></td>
       <td><input type="text" inputmode="decimal" step="0.01" class="adjHrsInput" data-id="${id}" data-type="reg" value="${regValue}" /></td>
       <td><input type="text" inputmode="decimal" step="0.01" class="adjHrsInput" data-id="${id}" data-type="ot" value="${otValue}" /></td>
+      <td class="adjPrintCell"></td>
     `;
+    const printCell = tr.querySelector('.adjPrintCell');
+    if (printCell) {
+      const hasAdjustmentValue = Math.abs(Number(totals.reg) || 0) > 0.004 || Math.abs(Number(totals.ot) || 0) > 0.004;
+      printCell.innerHTML = hasAdjustmentValue
+        ? `<button type="button" class="adjustmentPayslipBtn" data-id="${id}">Print</button>`
+        : '-';
+    }
     const typeCell = tr.querySelector('.adjTypeCell');
     if (typeCell) {
       const select = document.createElement('select');
@@ -9287,6 +9296,7 @@ function renderAdjustmentHoursTable(){
     <td></td>
     <td class="num" data-col="regHours">${formatZeroDisplay(grandRegTotal)}</td>
     <td class="num" data-col="otHours">${formatZeroDisplay(grandOtTotal)}</td>
+    <td></td>
   `;
   tbody.appendChild(totalRow);
   const formatAdjustmentHoursInput = (input) => {
@@ -20905,6 +20915,25 @@ document.addEventListener('DOMContentLoaded', function(){
 
 <!-- Payslip Button functionality -->
 <script>
+// Add click listener for adjustment tab print buttons (only for rows with values)
+document.addEventListener('click', function(e) {
+  var target = e.target;
+  if (!target || !target.classList || !target.classList.contains('adjustmentPayslipBtn')) return;
+  var empId = (target.getAttribute('data-id') || '').trim();
+  if (!empId) return;
+  var payrollRow = document.querySelector('#payrollTable tbody tr[data-id="' + empId.replace(/"/g, '\"') + '"]');
+  if (!payrollRow) {
+    var rows = document.querySelectorAll('#payrollTable tbody tr');
+    for (var i = 0; i < rows.length; i++) {
+      var rowId = (rows[i].cells && rows[i].cells[0] ? rows[i].cells[0].textContent : '').toString().trim();
+      if (rowId === empId) { payrollRow = rows[i]; break; }
+    }
+  }
+  if (!payrollRow) return;
+  var payslipBtn = payrollRow.querySelector('.payslipBtn');
+  if (payslipBtn) payslipBtn.click();
+});
+
 // Add click listener for payslip buttons on payroll table
 document.addEventListener('click', function(e) {
   var target = e.target;


### PR DESCRIPTION
### Motivation
- Provide a quick way to print an employee payslip from the Adjustments tab when an employee has adjustment hours so users don't need to switch to the Payroll tab. 
- Reuse the existing payslip generation/printing flow to avoid duplicating print logic.

### Description
- Added a `Print` column to the Adjustments table header in `index.html` and added an empty print cell to each employee row (`.adjPrintCell`).
- Render a per-employee `Print` button (`.adjustmentPayslipBtn`) only when the employee has a non-zero REG or ADJ OT adjustment value, otherwise display `-`.
- Added a click handler that finds the corresponding payroll row (tries `data-id` lookup then falls back to scanning first cell text) and triggers the existing payroll `.payslipBtn` to reuse the established payslip print flow.
- Kept the grand total row layout consistent by adding an empty print cell for the totals row.

### Testing
- Ran `git status --short` to verify the working tree and it completed successfully.
- Created the change and committed (`git commit`) successfully; no automated test suite was executed for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc34057f0083288e9c23b59a43e31c)