### PR TITLE
Fix ADJ OT computation in Reports Detailed tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -13131,11 +13131,12 @@ return { rootHash, manifestHash, segmentCount: Object.keys(segments).length, ver
         const hours = Number.isFinite(hoursRaw) ? roundToCents(hoursRaw) : 0;
         const explicitAmount = Number(entry.amount ?? entry.adjPay ?? entry.pay ?? entry.total ?? NaN);
         const rate = getReportEmployeeRate(normalizedEmployeeId, entry.name);
-        const amount = Number.isFinite(explicitAmount)
-          ? roundToCents(explicitAmount)
-          : roundToCents(hours * rate);
         const kind = normalizeAdjustmentType(entry.type ?? entry.kind ?? entry.label ?? entry.name ?? entry.category ?? entry.adjustmentType ?? entry.entryType);
         const effectiveOtRate = getEffectiveOvertimeRateForEmployee(normalizedEmployeeId, rate);
+        const derivedRate = (kind === 'ADJ OT') ? effectiveOtRate : rate;
+        const amount = Number.isFinite(explicitAmount)
+          ? roundToCents(explicitAmount)
+          : roundToCents(hours * derivedRate);
 
         if (!buckets[bucket]) buckets[bucket] = {};
         if (!buckets[bucket][normalizedEmployeeId]) {


### PR DESCRIPTION
### Motivation
- The Detailed Reports subtab was undercounting adjustment overtime when ADJ OT entries provided hours but no explicit amount because the fallback used the regular hourly rate.
- Ensure ADJ OT adjustments derive amounts using the effective overtime rate so totals in the Detailed report match payroll overtime calculations.

### Description
- Updated `buildDetailedAdjustmentsByProject()` / `addEntry()` in `index.html` to compute `kind` before deriving the fallback amount. 
- Introduced `derivedRate = (kind === 'ADJ OT') ? effectiveOtRate : rate` and use `hours * derivedRate` when no explicit amount is present. 
- Preserved existing behavior for explicit adjustment amounts and for non-OT adjustments by keeping explicit amounts and regular-rate computation unchanged.

### Testing
- No automated tests were executed for this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc35ad9abc832880812f34bf05a808)