### PR TITLE
Loan tracker: subtract paid baseline and clamp per-period deductions to remaining balance

### DIFF
--- a/index.html
+++ b/index.html
@@ -6543,7 +6543,9 @@ function renderLoanTrackerTable(){
 
       const basePer = (entry.active && monthly > 0) ? roundToCents((div || 1) > 0 ? (monthly / (div || 1)) : monthly) : 0;
       const paidBefore = sumLoanTrackerAppliedBefore(pk, empId, type);
-      const remainingBefore = roundToCents(principal - paidBefore);
+      const baseline = loanTrackerPaidBaseline(entry, type);
+      const effectivePaidBefore = Math.max(0, roundToCents(paidBefore - baseline));
+      const remainingBefore = roundToCents(principal - effectivePaidBefore);
       const desired = (entry.active && basePer > 0 && remainingBefore > 0) ? roundToCents(Math.min(basePer, remainingBefore)) : 0;
 
       const scheduled = getLoanTrackerApplied(pk, empId, type);
@@ -6599,13 +6601,16 @@ function renderLoanTrackerTable(){
       const principal = roundToCents(entry.principal || 0);
       const weekly = roundToCents(entry.weekly || 0);
       const paidBefore = sumLoanTrackerAppliedBefore(pk, empId, type);
-      const remainingBefore = roundToCents(principal - paidBefore);
+      const baseline = loanTrackerPaidBaseline(entry, type);
+      const effectivePaidBefore = Math.max(0, roundToCents(paidBefore - baseline));
+      const remainingBefore = roundToCents(principal - effectivePaidBefore);
       const scheduled = getLoanTrackerApplied(pk, empId, type);
-      const currentDeduction = (scheduled != null)
+      const unclampedCurrentDeduction = (scheduled != null)
         ? roundToCents(Number(scheduled) || 0)
         : ((entry.active && weekly > 0 && remainingBefore > 0)
           ? roundToCents(Math.min(weekly, remainingBefore))
           : 0);
+      const currentDeduction = roundToCents(Math.max(0, Math.min(unclampedCurrentDeduction, remainingBefore)));
       const bal = roundToCents(Math.max(0, remainingBefore - currentDeduction));
 
       const tdPrincipal = document.createElement('td');


### PR DESCRIPTION
### Motivation

- Ensure remaining loan balances used for scheduling and display exclude any baseline/previously accounted payments and never go negative.
- Prevent scheduled weekly/monthly deductions from exceeding the true remaining balance and avoid negative balances after applying a deduction.

### Description

- Use `loanTrackerPaidBaseline(entry, type)` to compute a baseline offset and subtract it from `sumLoanTrackerAppliedBefore(pk, empId, type)` to produce an `effectivePaidBefore` for remaining balance calculation. 
- Update remaining-before logic in both monthly and weekly cell renderers to use `effectivePaidBefore` and `roundToCents` for consistent rounding. 
- For weekly deductions compute an `unclampedCurrentDeduction` then clamp it with `Math.max(0, Math.min(unclampedCurrentDeduction, remainingBefore))` to produce `currentDeduction` and compute `bal` as `Math.max(0, remainingBefore - currentDeduction)`. 
- Ensure numeric values are normalized with `roundToCents` and non-negative via `Math.max(0, ...)` where appropriate.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3ac22d4c83289b62850fcd5ddf3e)