### PR TITLE
Fix adjustments print to include selected project

### DIFF
--- a/index.html
+++ b/index.html
@@ -10015,6 +10015,17 @@ document.addEventListener('DOMContentLoaded', function(){
       return;
     }
     const clone = table.cloneNode(true);
+    clone.querySelectorAll('select').forEach(function(select){
+      var cell = select.closest('td');
+      if (!cell) return;
+      var selectedText = '';
+      try {
+        selectedText = select.options && select.selectedIndex >= 0
+          ? String(select.options[select.selectedIndex].textContent || '').trim()
+          : '';
+      } catch (_) {}
+      cell.textContent = selectedText || '(none)';
+    });
     clone.querySelectorAll('input').forEach(function(input){
       var cell = input.closest('td');
       if (!cell) return;


### PR DESCRIPTION
### Motivation
- The Adjustments subtab print output omitted the chosen project because the print flow only converted `<input>` fields to text and did not handle `<select>` project pickers.

### Description
- Before printing the adjustments table the code now converts each `<select>` in the cloned table into its selected option label and writes that text into the containing cell, with a fallback label of `(none)` when nothing is selected.

### Testing
- No automated tests were executed for this UI-only change (no existing automated coverage for the adjustments print flow).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0572c9f32083288c116f3b8c688a73)