### PR TITLE
Print: convert adjustment select fields to plain text in cloned print table

### DIFF
--- a/index.html
+++ b/index.html
@@ -10015,6 +10015,21 @@ document.addEventListener('DOMContentLoaded', function(){
       return;
     }
     const clone = table.cloneNode(true);
+    const sourceProjectSelects = table.querySelectorAll('select.adjTypeSelect');
+    const clonedProjectSelects = clone.querySelectorAll('select.adjTypeSelect');
+    clonedProjectSelects.forEach(function(select, idx){
+      var sourceSelect = sourceProjectSelects[idx];
+      var cell = select.closest('td');
+      if (!cell) return;
+      var selectedText = '';
+      try {
+        const resolvedSelect = sourceSelect || select;
+        selectedText = resolvedSelect.options && resolvedSelect.selectedIndex >= 0
+          ? String(resolvedSelect.options[resolvedSelect.selectedIndex].textContent || '').trim()
+          : '';
+      } catch (_) {}
+      cell.textContent = selectedText || '(none)';
+    });
     clone.querySelectorAll('input').forEach(function(input){
       var cell = input.closest('td');
       if (!cell) return;


### PR DESCRIPTION
### Motivation
- Ensure that `select.adjTypeSelect` elements in the adjustments table render their selected option text when the table is cloned for the printed "Adjustments Report" so the printed output shows readable values instead of interactive controls.

### Description
- When cloning the `#adjustmentHoursTable` for printing, find matching `select.adjTypeSelect` elements in the source and cloned tables and replace the cloned select cell content with the selected option text or `'(none)'` as a fallback.
- Preserve existing formatting for inputs by converting cloned `input` values to formatted text (two decimals or `'-'`) as before, and include defensive checks and a `try/catch` to avoid runtime errors when resolving option text.

### Testing
- Ran the existing automated frontend test suite (`npm test`) and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0572c9f32083288c116f3b8c688a73)